### PR TITLE
Added a workaround for MSVC 12 (VS2013) optimizer bug.

### DIFF
--- a/include/boost/uuid/detail/uuid_x86.hpp
+++ b/include/boost/uuid/detail/uuid_x86.hpp
@@ -56,7 +56,7 @@ BOOST_FORCEINLINE __m128i load_unaligned_si128(const uint8_t* p) BOOST_NOEXCEPT
     return mm;
 #else
     // VS2008 x64 doesn't respect _ReadWriteBarrier above, so we have to generate this crippled code to load unaligned data
-    return _mm_unpacklo_epi64(_mm_loadl_epi64(reinterpret_cast< const __m128i* >(p)), _mm_loadl_epi64(reinterpret_cast< const __m128i* >(p) + 1));
+    return _mm_unpacklo_epi64(_mm_loadl_epi64(reinterpret_cast< const __m128i* >(p)), _mm_loadl_epi64(reinterpret_cast< const __m128i* >(p + 8)));
 #endif
 }
 

--- a/include/boost/uuid/detail/uuid_x86.hpp
+++ b/include/boost/uuid/detail/uuid_x86.hpp
@@ -22,11 +22,13 @@
 #include <emmintrin.h>
 #endif
 
-#if defined(BOOST_MSVC) && BOOST_MSVC == 1800
-// MSVC 12 (VS2013) has an optimizer bug that sometimes results in incorrect SIMD code generated in Release x64 mode.
-// In particular, it affects operator==, where the compiler sometimes generates pcmpeqd with a memory opereand
-// instead of movdqu followed by pcmpeqd. The problem is that uuid can be not aligned to 16 bytes and pcmpeqd
-// causes alignment violation in this case.
+#if defined(BOOST_MSVC)
+// At least MSVC 9 (VS2008) and 12 (VS2013) have an optimizer bug that sometimes results in incorrect SIMD code
+// generated in Release x64 mode. In particular, it affects operator==, where the compiler sometimes generates
+// pcmpeqd with a memory opereand instead of movdqu followed by pcmpeqd. The problem is that uuid can be
+// not aligned to 16 bytes and pcmpeqd causes alignment violation in this case. We cannot be sure that other
+// MSVC versions are not affected so we apply the workaround for all versions. It doesn't seem to cause any
+// serious negative consequences anyway.
 //
 // https://svn.boost.org/trac/boost/ticket/8509#comment:3
 // https://connect.microsoft.com/VisualStudio/feedbackdetail/view/981648#tabs

--- a/test/Jamfile.v2
+++ b/test/Jamfile.v2
@@ -54,5 +54,9 @@ test-suite uuid :
 
     # test sha1 hash function
     [ run test_sha1.cpp ]
+
+    # test MSVC 12 (VS2013) optimizer bug with SIMD operations. See https://svn.boost.org/trac/boost/ticket/8509#comment:3.
+    # Only happens in Release x64 builds.
+    [ run test_msvc_simd_bug981648_main.cpp test_msvc_simd_bug981648_foo.cpp : : : <variant>release <debug-symbols>on : test_msvc_simd_bug981648 ]
     ;
 

--- a/test/test_msvc_simd_bug981648.hpp
+++ b/test/test_msvc_simd_bug981648.hpp
@@ -1,0 +1,38 @@
+/*
+ * Copyright 2014 Andrey Semashev
+ *
+ * Distributed under the Boost Software License, Version 1.0.
+ * See accompanying file LICENSE_1_0.txt or copy at
+ * http://www.boost.org/LICENSE_1_0.txt
+ */
+/*
+ * This is a part of the test for a workaround for MSVC 12 (VS2013) optimizer bug
+ * which causes incorrect SIMD code generation for operator==. See:
+ *
+ * https://svn.boost.org/trac/boost/ticket/8509#comment:3
+ * https://connect.microsoft.com/VisualStudio/feedbackdetail/view/981648#tabs
+ *
+ * The header contains common definitions for the two source files.
+ */
+
+#include <boost/uuid/uuid.hpp>
+
+using boost::uuids::uuid;
+
+class headerProperty
+{
+public:
+    virtual ~headerProperty() {}
+};
+
+class my_obj:
+    public headerProperty
+{
+public:
+    // This char tmp[8] forces the following uuid to be misaligned.
+    char tmp[8];
+    // This m_uuid is misaligned (not 16-byte aligned) and causes the != operator to crash.
+    uuid m_uuid;
+    const uuid &get_marker_id() const { return m_uuid;  }
+    uuid get_id() const { return m_uuid;  }
+};

--- a/test/test_msvc_simd_bug981648_foo.cpp
+++ b/test/test_msvc_simd_bug981648_foo.cpp
@@ -1,0 +1,33 @@
+/*
+ * Copyright 2014 Andrey Semashev
+ *
+ * Distributed under the Boost Software License, Version 1.0.
+ * See accompanying file LICENSE_1_0.txt or copy at
+ * http://www.boost.org/LICENSE_1_0.txt
+ */
+/*
+ * This is a part of the test for a workaround for MSVC 12 (VS2013) optimizer bug
+ * which causes incorrect SIMD code generation for operator==. See:
+ *
+ * https://svn.boost.org/trac/boost/ticket/8509#comment:3
+ * https://connect.microsoft.com/VisualStudio/feedbackdetail/view/981648#tabs
+ *
+ * The file contains the function that actually causes the crash. Reproduces only
+ * in Release x64 builds.
+ */
+
+#include <cstdio>
+#include "test_msvc_simd_bug981648.hpp"
+
+void mp_grid_update_marker_parameters(headerProperty* header_prop, my_obj &current_marker)
+{
+    headerProperty *old_header_prop = NULL;
+    my_obj *p = dynamic_cast<my_obj*>(header_prop);
+    /*
+     * This != statement crashes with a GP.
+     * */
+    if (p != NULL && (current_marker.get_id() != p->get_marker_id())) {
+        std::printf("works okay, if it reaches this printf: %lx\n", (long)p);
+        old_header_prop = header_prop;
+    }
+}

--- a/test/test_msvc_simd_bug981648_main.cpp
+++ b/test/test_msvc_simd_bug981648_main.cpp
@@ -25,10 +25,21 @@ static my_obj g_my_obj;
 int main(int argc, char* argv[])
 {
     my_obj *p = &g_my_obj;
-    my_obj a;
 
-    p->m_uuid = a.m_uuid = uuid();
+    p->m_uuid = uuid();
+
+    uuid one, two;
+    one.data[0] = 0; two.data[0] = 1;
+
+    //*****************************************
+    // This != statement generates two movdqu statements or pcmpeqd with a memory operand which crashes
+    if (one != two) {
+        std::printf("The first != operator works okay if it reaches this printf.\n");
+    }
+    my_obj a;
     a.m_uuid.data[0] = 1;
+
+    std::printf("There should be a another printf coming next.\n");
 
     //*****************************************
     // The != statement in this function generates a movups and a movdqu statement.

--- a/test/test_msvc_simd_bug981648_main.cpp
+++ b/test/test_msvc_simd_bug981648_main.cpp
@@ -1,0 +1,39 @@
+/*
+ * Copyright 2014 Andrey Semashev
+ *
+ * Distributed under the Boost Software License, Version 1.0.
+ * See accompanying file LICENSE_1_0.txt or copy at
+ * http://www.boost.org/LICENSE_1_0.txt
+ */
+/*
+ * This is a part of the test for a workaround for MSVC 12 (VS2013) optimizer bug
+ * which causes incorrect SIMD code generation for operator==. See:
+ *
+ * https://svn.boost.org/trac/boost/ticket/8509#comment:3
+ * https://connect.microsoft.com/VisualStudio/feedbackdetail/view/981648#tabs
+ *
+ * This file contains the main entry point.
+ */
+
+#include <cstdio>
+#include "test_msvc_simd_bug981648.hpp"
+
+extern void mp_grid_update_marker_parameters(headerProperty* header_prop, my_obj &current_marker);
+
+static my_obj g_my_obj;
+
+int main(int argc, char* argv[])
+{
+    my_obj *p = &g_my_obj;
+    my_obj a;
+
+    p->m_uuid = a.m_uuid = uuid();
+    a.m_uuid.data[0] = 1;
+
+    //*****************************************
+    // The != statement in this function generates a movups and a movdqu statement.
+    // It also crashes because the optimizer also creates a pcmpeqd for a non-aligned memory location.
+    mp_grid_update_marker_parameters(p, a);
+	
+    return 0;
+}


### PR DESCRIPTION
The compiler incorrectly merges unaligned loads with SIMD comparison
instruction, which causes crashes in Release x64 builds.

https://svn.boost.org/trac/boost/ticket/8509#comment:3
https://connect.microsoft.com/VisualStudio/feedbackdetail/view/981648#tabs