### PR TITLE
fix for the non-MSVC case on Windows

### DIFF
--- a/include/boost/uuid/seed_rng.hpp
+++ b/include/boost/uuid/seed_rng.hpp
@@ -37,14 +37,19 @@
 //#include <boost/generator_iterator.hpp>
 # include <boost/iterator/iterator_facade.hpp>
 
-#if defined(BOOST_WINDOWS)
+#if defined(_MSC_VER)
 #   pragma warning(push) // Save warning settings.
 #   pragma warning(disable : 4996) // Disable deprecated std::fopen
+#endif
+
+#if defined(BOOST_WINDOWS)
 #   include <boost/detail/winapi/crypt.hpp> // for CryptAcquireContextA, CryptGenRandom, CryptReleaseContext
 #   include <boost/detail/winapi/timers.hpp>
 #   include <boost/detail/winapi/process.hpp>
 #   include <boost/detail/winapi/thread.hpp>
+#if defined(_MSC_VER)
 #   pragma comment(lib, "advapi32.lib")
+#endif
 #else 
 #   include <sys/time.h>  // for gettimeofday
 #   include <sys/types.h> // for pid_t

--- a/include/boost/uuid/seed_rng.hpp
+++ b/include/boost/uuid/seed_rng.hpp
@@ -37,7 +37,7 @@
 //#include <boost/generator_iterator.hpp>
 # include <boost/iterator/iterator_facade.hpp>
 
-#if defined(_MSC_VER)
+#if defined(BOOST_WINDOWS)
 #   pragma warning(push) // Save warning settings.
 #   pragma warning(disable : 4996) // Disable deprecated std::fopen
 #   include <boost/detail/winapi/crypt.hpp> // for CryptAcquireContextA, CryptGenRandom, CryptReleaseContext

--- a/include/boost/uuid/seed_rng.hpp
+++ b/include/boost/uuid/seed_rng.hpp
@@ -40,6 +40,7 @@
 #if defined(_MSC_VER)
 #   pragma warning(push) // Save warning settings.
 #   pragma warning(disable : 4996) // Disable deprecated std::fopen
+#   pragma comment(lib, "advapi32.lib")
 #endif
 
 #if defined(BOOST_WINDOWS)
@@ -47,9 +48,6 @@
 #   include <boost/detail/winapi/timers.hpp>
 #   include <boost/detail/winapi/process.hpp>
 #   include <boost/detail/winapi/thread.hpp>
-#if defined(_MSC_VER)
-#   pragma comment(lib, "advapi32.lib")
-#endif
 #else 
 #   include <sys/time.h>  // for gettimeofday
 #   include <sys/types.h> // for pid_t


### PR DESCRIPTION
... such as MinGW, with which g++ generates the following errors during building client code using boost::uuids::basic_random_generator:
> In file included from /foo/bar/include/boost/uuid/random_generator.hpp:12:0,
>                  from /foo/bar/include/boost/uuid/uuid_generators.hpp:17,
>                  from ../../../../src/uuidgen.h:8,
>                  from ../../../../src/baz/quux.cc:28:
> /foo/bar/include/boost/uuid/seed_rng.hpp:240:20: error: 'winapi' in namespace 'boost::detail' does not name a type
>      boost::detail::winapi::HCRYPTPROV_ random_;
>                     ^
> /foo/bar/include/boost/uuid/seed_rng.hpp: In constructor 'boost::uuids::detail::seed_rng::seed_rng()':
> /foo/bar/include/boost/uuid/seed_rng.hpp:89:11: error: class 'boost::uuids::detail::seed_rng' does not have any field named 'random_'
>          , random_(NULL)
>            ^
> /foo/bar/include/boost/uuid/seed_rng.hpp:92:29: error: 'boost::detail::winapi' has not been declared
>          if (!boost::detail::winapi::CryptAcquireContextA(
>                              ^
> /foo/bar/include/boost/uuid/seed_rng.hpp:93:22: error: 'random_' was not declared in this scope
>                      &random_,
>                       ^
> /foo/bar/include/boost/uuid/seed_rng.hpp:96:36: error: 'boost::detail::winapi' has not been declared
>                      boost::detail::winapi::PROV_RSA_FULL_,
>                                     ^
> /foo/bar/include/boost/uuid/seed_rng.hpp:97:36: error: 'boost::detail::winapi' has not been declared
>                      boost::detail::winapi::CRYPT_VERIFYCONTEXT_ | boost::detail::winapi::CRYPT_SILENT_))
>                                     ^
> /foo/bar/include/boost/uuid/seed_rng.hpp:97:82: error: 'boost::detail::winapi' has not been declared
>                      boost::detail::winapi::CRYPT_VERIFYCONTEXT_ | boost::detail::winapi::CRYPT_SILENT_))
>                                                                                   ^
> /foo/bar/include/boost/uuid/seed_rng.hpp: In destructor 'boost::uuids::detail::seed_rng::~seed_rng()':
> /foo/bar/include/boost/uuid/seed_rng.hpp:110:13: error: 'random_' was not declared in this scope
>          if (random_) {
>              ^
> /foo/bar/include/boost/uuid/seed_rng.hpp:112:28: error: 'boost::detail::winapi' has not been declared
>              boost::detail::winapi::CryptReleaseContext(random_, 0);
>                             ^
> /foo/bar/include/boost/uuid/seed_rng.hpp: In member function 'void boost::uuids::detail::seed_rng::sha1_random_digest_()':
> /foo/bar/include/boost/uuid/seed_rng.hpp:155:13: error: 'random_' was not declared in this scope
>          if (random_)
>              ^
> /foo/bar/include/boost/uuid/seed_rng.hpp:160:28: error: 'boost::detail::winapi' has not been declared
>              boost::detail::winapi::CryptGenRandom(random_, sizeof(state), state);
>                             ^
> /foo/bar/include/boost/uuid/seed_rng.hpp:170:28: error: 'boost::detail::winapi' has not been declared
>              boost::detail::winapi::DWORD_ procid = boost::detail::winapi::GetCurrentProcessId();
>                             ^
> /foo/bar/include/boost/uuid/seed_rng.hpp:171:55: error: 'procid' was not declared in this scope
>              sha.process_bytes( (unsigned char const*)&procid, sizeof( procid ) );
>                                                        ^
> /foo/bar/include/boost/uuid/seed_rng.hpp:173:28: error: 'boost::detail::winapi' has not been declared
>              boost::detail::winapi::DWORD_ threadid = boost::detail::winapi::GetCurrentThreadId();
>                             ^
> /foo/bar/include/boost/uuid/seed_rng.hpp:174:55: error: 'threadid' was not declared in this scope
>              sha.process_bytes( (unsigned char const*)&threadid, sizeof( threadid ) );
>                                                        ^
> /foo/bar/include/boost/uuid/seed_rng.hpp:176:28: error: 'boost::detail::winapi' has not been declared
>              boost::detail::winapi::LARGE_INTEGER_ ts;
>                             ^
> /foo/bar/include/boost/uuid/seed_rng.hpp:177:13: error: 'ts' was not declared in this scope
>              ts.QuadPart = 0;
>              ^
> /foo/bar/include/boost/uuid/seed_rng.hpp:178:28: error: 'boost::detail::winapi' has not been declared
>              boost::detail::winapi::QueryPerformanceCounter( &ts );
>                             ^
