### PR TITLE
Add a check for AVX in VS2013 and later

### DIFF
--- a/include/boost/uuid/detail/config.hpp
+++ b/include/boost/uuid/detail/config.hpp
@@ -36,15 +36,23 @@
 #define BOOST_UUID_USE_SSE41
 #endif
 
-#elif defined(_MSC_VER) && (defined(_M_X64) || (defined(_M_IX86) && defined(_M_IX86_FP) && _M_IX86_FP >= 2))
+#elif defined(_MSC_VER)
 
-#ifndef BOOST_UUID_USE_SSE2
+#if (defined(_M_X64) || (defined(_M_IX86) && defined(_M_IX86_FP) && _M_IX86_FP >= 2)) && !defined(BOOST_UUID_USE_SSE2)
 #define BOOST_UUID_USE_SSE2
 #endif
 
-#elif !defined(BOOST_UUID_USE_SSE41) && !defined(BOOST_UUID_USE_SSE3) && !defined(BOOST_UUID_USE_SSE2)
-
-#define BOOST_UUID_NO_SIMD
+#if defined(__AVX__)
+#if !defined(BOOST_UUID_USE_SSE41)
+#define BOOST_UUID_USE_SSE41
+#endif
+#if !defined(BOOST_UUID_USE_SSE3)
+#define BOOST_UUID_USE_SSE3
+#endif
+#if !defined(BOOST_UUID_USE_SSE2)
+#define BOOST_UUID_USE_SSE2
+#endif
+#endif
 
 #endif
 
@@ -55,6 +63,10 @@
 
 #if !defined(BOOST_UUID_USE_SSE2) && defined(BOOST_UUID_USE_SSE3)
 #define BOOST_UUID_USE_SSE2
+#endif
+
+#if !defined(BOOST_UUID_NO_SIMD) && !defined(BOOST_UUID_USE_SSE41) && !defined(BOOST_UUID_USE_SSE3) && !defined(BOOST_UUID_USE_SSE2)
+#define BOOST_UUID_NO_SIMD
 #endif
 
 #endif // !defined(BOOST_UUID_NO_SIMD)

--- a/include/boost/uuid/detail/uuid_x86.hpp
+++ b/include/boost/uuid/detail/uuid_x86.hpp
@@ -87,9 +87,9 @@ inline bool operator== (uuid const& lhs, uuid const& rhs) BOOST_NOEXCEPT
     __m128i mm_right = uuids::detail::load_unaligned_si128(rhs.data);
 
     __m128i mm_cmp = _mm_cmpeq_epi32(mm_left, mm_right);
-    
+
 #if defined(BOOST_UUID_USE_SSE41)
-    return _mm_test_all_ones(mm_cmp);
+    return _mm_test_all_ones(mm_cmp) != 0;
 #else
     return _mm_movemask_epi8(mm_cmp) == 0xFFFF;
 #endif


### PR DESCRIPTION
The pull request enables all SSE extensions when AVX is enabled with MSVC compiler switches. It also silences an MSVC warning.