### PR TITLE
Fix compilation with BOOST_NO_ANSI_APIS

### DIFF
--- a/include/boost/uuid/seed_rng.hpp
+++ b/include/boost/uuid/seed_rng.hpp
@@ -92,7 +92,7 @@ public:
         , random_(NULL)
     {
 #if defined(BOOST_WINDOWS)
-        if (!boost::detail::winapi::CryptAcquireContextA(
+        if (!boost::detail::winapi::CryptAcquireContextW(
                     &random_,
                     NULL,
                     NULL,


### PR DESCRIPTION
With BOOST_NO_ANSI_APIS, there is no CryptAcquireContextA.