### PR TITLE
12258: re-enable unit test for random_device generator

### DIFF
--- a/test/Jamfile.v2
+++ b/test/Jamfile.v2
@@ -34,7 +34,7 @@ test-suite uuid :
     [ run test_nil_generator.cpp ]
     [ run test_name_generator.cpp ]
     [ run test_string_generator.cpp ]
-    [ run test_random_generator.cpp ]
+    [ run test_random_generator.cpp ../../random/build//boost_random ]
 
     # test tagging an object
     [ run test_tagging.cpp ]

--- a/test/test_random_generator.cpp
+++ b/test/test_random_generator.cpp
@@ -14,6 +14,7 @@
 #include <boost/uuid/uuid_io.hpp>
 #include <boost/detail/lightweight_test.hpp>
 #include <boost/random.hpp>
+#include <boost/random/random_device.hpp>
 
 template <typename RandomUuidGenerator>
 void check_random_generator(RandomUuidGenerator& uuid_gen)
@@ -53,8 +54,8 @@ int main(int, char*[])
     check_random_generator(uuid_gen4);
 
     // random device
-    //basic_random_generator<boost::random_device> uuid_gen5;
-    //check_random_generator(uuid_gen5);
+    basic_random_generator<boost::random::random_device> uuid_gen5;
+    check_random_generator(uuid_gen5);
     
     // there was a bug in basic_random_generator where it did not
     // produce very random numbers.  This checks for that bug.


### PR DESCRIPTION
Investigating Trac 12258 I found the random_device unit test was not enabled.  This establishes a formal dependency during the build of uuid on random, but that seems quite appropriate.  Tested on Windows (MSVC2015) and Linux (gcc-4.8, trusty).