### PR TITLE
enable coverity scan builds on develop merge into master

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,10 @@
 # Copyright 2016 Peter Dimov
+# Copyright 2017 James E. King, III
 # Distributed under the Boost Software License, Version 1.0.
 # (See accompanying file LICENSE_1_0.txt or copy at http://boost.org/LICENSE_1_0.txt)
 
 #
-# Generic Travis CI build script
+# Generic Travis CI build script for boostorg repositories
 # For instructions on setting up your own fork and running CI builds before submitting
 # your changes into the official repository, see:
 # https://svn.boost.org/trac10/wiki/TravisCoverals
@@ -22,22 +23,14 @@
 # 3. If your project builds a library (is not header-only) you can get coveralls
 #    code coverage analysis by uncommenting the coverage job and copying the
 #    compute/.coveralls.yml file into your repository.
+# 4. If you want to enable Coverity Scan, you need to provide the environment
+#    variables COVERITY_SCAN_TOKEN and COVERITY_SCAN_NOTIFICATION_EMAIL.  
 #
 # That's it - the script will do everything else for you.
 
-language: cpp
-
 sudo: false
 dist: trusty
-
-os:
-  - linux
-  - osx
-
-branches:
-  only:
-    - develop
-    - master
+language: cpp
 
 env:
   global:
@@ -47,111 +40,6 @@ env:
     # - B2_LINK=link=shared,static
     # - B2_THREADING=threading=multi,single
     - B2_VARIANT=variant=release,debug
-
-  matrix:
-    # This disables all built-in matrix build generation.
-    # We'll be specific about compilers and options.
-    - BOGUS_JOB=true
-
-addons:
-  apt:
-    packages:
-      - binutils-gold
-      - gdb
-      - libc6-dbg
-    
-matrix:
-  exclude:
-    - env: BOGUS_JOB=true
-
-  include:
-    # C++03 using ancient compilers
-    - os: linux
-      env: COMMENT="c++03 gcc-4.8" TOOLSET=gcc COMPILER=g++ CXXSTD=c++03
-    - os: linux
-      env: COMMENT="c++03 clang-3.4" TOOLSET=clang COMPILER=clang++ CXXSTD=c++03
-
-    # C++11 using older compilers
-    # - os: linux
-    #   env: COMMENT="c++11 gcc-5" TOOLSET=gcc COMPILER=g++-5 CXXSTD=c++11
-    #   addons:
-    #     apt:
-    #       packages:
-    #         - g++-5
-    #       sources:
-    #         - ubuntu-toolchain-r-test
-    # - os: linux
-    #   env: COMMENT="c++11 clang-3.8" TOOLSET=clang COMPILER=clang++-3.8 CXXSTD=c++11
-    #   addons:
-    #     apt:
-    #       packages:
-    #         - clang-3.8
-    #         - g++-5
-    #       sources:
-    #         - llvm-toolchain-trusty-3.8
-    #         - ubuntu-toolchain-r-test
-
-    # C++14 using recent compilers
-    # - os: linux
-    #   env: COMMENT="c++14 gcc-6" TOOLSET=gcc COMPILER=g++-6 CXXSTD=c++14
-    #   addons:
-    #     apt:
-    #       packages:
-    #         - g++-6
-    #       sources:
-    #         - ubuntu-toolchain-r-test
-    # - os: linux
-    #   env: COMMENT="c++14 clang-4.0" TOOLSET=clang COMPILER=clang++-4.0 CXXSTD=c++14
-    #   addons:
-    #     apt:
-    #       packages:
-    #         - clang-4.0
-    #         - g++-6
-    #       sources:
-    #         - llvm-toolchain-trusty-4.0
-    #         - ubuntu-toolchain-r-test
-
-    # C++17 using the latest compilers
-    - os: linux
-      env: COMMENT="c++17 gcc-7" TOOLSET=gcc COMPILER=g++-7 CXXSTD=c++17
-      addons:
-        apt:
-          packages:
-            - g++-7
-          sources:
-            - ubuntu-toolchain-r-test
-    - os: linux
-      env: COMMENT="c++17 clang-5.0" TOOLSET=clang COMPILER=clang++-5.0 CXXSTD=c++17
-      addons:
-        apt:
-          packages:
-            - clang-5.0
-            - g++-7
-          sources:
-            - llvm-toolchain-trusty-5.0
-            - ubuntu-toolchain-r-test
-
-    # Coverage build - for projects that build a library
-    # - os: linux
-    #   env: COMMENT="code coverage" TOOLSET=gcc COMPILER=g++-6 CXXSTD=c++11 B2_VARIANT="variant=profile cxxflags=--coverage linkflags=--coverage" COVERALL=1
-    #   addons:
-    #     apt:
-    #       packages:
-    #         - g++-6
-    #       sources:
-    #         - ubuntu-toolchain-r-test
-
-    - os: osx
-      env: TOOLSET=clang COMPILER=clang++ CXXSTD=c++03
-
-    # - os: osx
-    #   env: TOOLSET=clang COMPILER=clang++ CXXSTD=c++11
-
-    # - os: osx
-    #   env: TOOLSET=clang COMPILER=clang++ CXXSTD=c++14
-
-    # - os: osx
-    #   env: TOOLSET=clang COMPILER=clang++ CXXSTD=c++1z
 
 install:
   - export SELF=`basename $TRAVIS_BUILD_DIR`
@@ -168,15 +56,115 @@ install:
   - ./bootstrap.sh
   - ./b2 headers
 
+addons:
+  apt:
+    packages:
+      - binutils-gold
+      - gdb
+      - libc6-dbg
+        
+branches:
+  only:
+    - develop
+    - master
+    
 script:
-  - export COMPILER_VERSION=`$COMPILER --version`
   - |-
     echo "using $TOOLSET : : $COMPILER : <cxxflags>-std=$CXXSTD ;" > ~/user-config.jam
-  - |-
-    echo "[**] COMPILER: $COMPILER_VERSION [**]"
-  - |-
-    echo "./b2 libs/$SELF/test toolset=$TOOLSET $B2_ADDRESS_MODEL $B2_LINK $B2_THREADING $B2_VARIANT -j3"
-  - ./b2 libs/$SELF/test toolset=$TOOLSET $B2_ADDRESS_MODEL $B2_LINK $B2_THREADING $B2_VARIANT -j3
+  - ./b2 libs/$SELF/test toolset=$TOOLSET $CXXFLAGS $LINKFLAGS $B2_ADDRESS_MODEL $B2_LINK $B2_THREADING $B2_VARIANT -j3
+
+jobs:
+  include:
+    # C++03 using stock compilers
+    - os: linux
+      env: 
+        - TOOLSET=gcc
+        - CXXSTD=c++03
+    - os: linux
+      env:
+        - TOOLSET=clang
+        - CXXSTD=c++03
+
+    # C++17 using the latest compilers
+    - os: linux
+      env: 
+        - TOOLSET=gcc
+        - COMPILER=g++-7
+        - CXXSTD=c++17
+      addons:
+        apt:
+          packages:
+            - g++-7
+          sources:
+            - ubuntu-toolchain-r-test
+    - os: linux
+      env: 
+        - TOOLSET=clang 
+        - COMPILER=clang++-5.0
+        - CXXSTD=c++17
+      addons:
+        apt:
+          packages:
+            - clang-5.0
+            - g++-7
+          sources:
+            - llvm-toolchain-trusty-5.0
+            - ubuntu-toolchain-r-test
+
+    - os: osx
+      env:
+        - TOOLSET=clang
+        - CXXSTD=c++03
+
+    - os: osx
+      osx_image: xcode9.1
+      env:
+        - TOOLSET=clang
+        - CXXSTD=c++03
+
+    # Coverage build - for projects that build a library
+    # - os: linux
+    #   env: 
+    #     - TOOLSET=gcc
+    #     - CXX=g++-6
+    #     - B2_VARIANT="variant=profile"
+    #     - CXXFLAGS="cxxflags=-std=c++03 cxxflags=--coverage"
+    #     - LINKFLAGS=linkflags=--coverage
+    #     - COVERALL=1
+    #   addons:
+    #     apt:
+    #       packages:
+    #         - g++-6
+    #       sources:
+    #         - ubuntu-toolchain-r-test
+
+    # Coverity Scan - runs on pull requests from develop into master if there is a coverity scan token in the environment
+    - os: linux
+      if: env(COVERITY_SCAN_TOKEN) IS present AND branch = master AND head_branch = develop
+      script:
+        - echo -n | openssl s_client -connect scan.coverity.com:443 | sed -ne '/-BEGIN CERTIFICATE-/,/-END CERTIFICATE-/p' | sudo tee -a /etc/ssl/certs/ca-
+        - libs/$SELF/covscan.sh
+      env:
+        - COMMENT="Coverity Scan"
+
+    # UBSAN build
+    - os: linux
+      env:
+        - COMMENT="UBSAN"
+        - B2_VARIANT=variant=debug
+        - TOOLSET=clang
+        - COMPILER=clang++-5.0
+        - CXXSTD=c++03
+        - CXXFLAGS="cxxflags=-fno-omit-frame-pointer cxxflags=-fsanitize=undefined cxxflags=-fsanitize=integer"
+        - LINKFLAGS="linkflags=-fsanitize=undefined"
+      addons:
+        apt:
+          packages:
+            - clang-5.0
+            - g++-7
+          sources:
+            - llvm-toolchain-trusty-5.0
+            - ubuntu-toolchain-r-test
 
 after_success:
   # If this is not a profiling build skip the rest...

--- a/README.md
+++ b/README.md
@@ -1,9 +1,20 @@
 Uuid, part of collection of the [Boost C++ Libraries](http://github.com/boostorg), provides a C++ wrapper around [RFC-4122](http://www.ietf.org/rfc/rfc4122.txt) UUIDs.
 
+### License
+
+Distributed under the [Boost Software License, Version 1.0](http://www.boost.org/LICENSE_1_0.txt).
+
 ### Properties
 
-* c++03
-* header-only
+* C++03
+* Header-only
+
+### Build Status
+
+Branch          | Travis | Appveyor | Coverity | Coveralls | Regression Tests
+--------------- | ------ | -------- | -------- | --------- | ----------------
+[develop](https://github.com/boostorg/uuid/tree/develop) | [![Build Status](https://travis-ci.org/boostorg/uuid.svg?branch=develop)](https://travis-ci.org/boostorg/uuid) | [![Build status](https://ci.appveyor.com/api/projects/status/nuihr6s92fjb9gwy/branch/develop?svg=true)](https://ci.appveyor.com/project/boostorg/uuid/branch/develop) | | N/A (Header-only) | [Enter the Matrix](http://www.boost.org/development/tests/develop/developer/uuid.html)
+[master](https://github.com/boostorg/uuid/tree/master) | [![Build Status](https://travis-ci.org/boostorg/uuid.svg?branch=master)](https://travis-ci.org/boostorg/uuid) | [![Build status](https://ci.appveyor.com/api/projects/status/nuihr6s92fjb9gwy?svg=true)](https://ci.appveyor.com/project/boostorg/uuid/branch/master) | [![Coverity Scan Build Status](https://scan.coverity.com/projects/13982/badge.svg)](https://scan.coverity.com/projects/boostorg-uuid) | N/A (Header-only) | [Enter the Matrix](http://www.boost.org/development/tests/master/developer/uuid.html)
 
 ### Directories
 
@@ -19,13 +30,31 @@ Uuid, part of collection of the [Boost C++ Libraries](http://github.com/boostorg
 * Submit your patches as pull requests against **develop** branch. Note that by submitting patches you agree to license your modifications under the [Boost Software License, Version 1.0](http://www.boost.org/LICENSE_1_0.txt).
 * Discussions about the library are held on the [Boost developers mailing list](http://www.boost.org/community/groups.html#main). Be sure to read the [discussion policy](http://www.boost.org/community/policy.html) before posting and add the `[uuid]` tag at the beginning of the subject line.
 
-### Build Status
+### Code Example - UUID Generation
 
-@               | Build         | Test coverage | Regression Test Matrix
---------------- | ------------- | ------------- | ----------------------
-[develop branch](https://github.com/boostorg/uuid/tree/develop): | [![Build Status](https://travis-ci.org/boostorg/uuid.svg?branch=develop)](https://travis-ci.org/boostorg/uuid) [![Build status](https://ci.appveyor.com/api/projects/status/nuihr6s92fjb9gwy/branch/develop?svg=true)](https://ci.appveyor.com/project/boostorg/uuid/branch/develop) | N/A (header-only) | [details...](http://www.boost.org/development/tests/develop/developer/uuid.html)
-[master branch](https://github.com/boostorg/uuid/tree/master):  | [![Build Status](https://travis-ci.org/boostorg/uuid.svg?branch=master)](https://travis-ci.org/boostorg/uuid) [![Build status](https://ci.appveyor.com/api/projects/status/nuihr6s92fjb9gwy?svg=true)](https://ci.appveyor.com/project/boostorg/uuid/branch/master) | N/A (header-only) | [details...](http://www.boost.org/development/tests/master/developer/uuid.html)
+    // Copyright 2017 James E. King, III
+    // Distributed under the Boost Software License, Version 1.0. 
+    // (See http://www.boost.org/LICENSE_1_0.txt)
+    // mkuuid.cpp example
+    
+    #include <boost/lexical_cast.hpp>
+    #include <boost/uuid/random_generator.hpp>
+    #include <boost/uuid/uuid_io.hpp>
+    #include <iostream>
+    
+    int main(void)
+    {
+        boost::uuids::random_generator gen;
+        std::cout << boost::lexical_cast<std::string>(gen()) << std::endl;
+        return 0;
+    }
+    
+    ----
+    
+    $ clang++ -ansi -Wall -Wextra -std=c++03 -O3 mkuuid.cpp -o mkuuid
+    $ ./mkuuid
+    2c186eb0-89cf-4a3c-9b97-86db1670d5f4
+    $ ./mkuuid
+    a9d3fbb9-0383-4389-a8a8-61f6629f90b6
 
-### License
 
-Distributed under the [Boost Software License, Version 1.0](http://www.boost.org/LICENSE_1_0.txt).

--- a/covscan.sh
+++ b/covscan.sh
@@ -1,0 +1,38 @@
+#! /bin/bash
+#
+# Copyright 2017 James E. King, III
+# Distributed under the Boost Software License, Version 1.0.
+# (See accompanying file LICENSE_1_0.txt or copy at
+#      http://www.boost.org/LICENSE_1_0.txt)
+#
+# Bash script to run in travis to perform a Coverity Scan build
+#
+
+#
+# Environment Variables
+#
+# COVERITY_SCAN_NOTIFICATION_EMAIL  - email address to notify
+# COVERITY_SCAN_TOKEN               - the Coverity Scan token (should be secure)
+# SELF                              - the boost libs directory name
+
+set -ex
+
+pushd /tmp
+rm -rf coverity_tool.tgz cov-analysis*
+wget https://scan.coverity.com/download/linux64 --post-data "token=$COVERITY_SCAN_TOKEN&project=boostorg/$SELF" -O coverity_tool.tgz
+tar xzf coverity_tool.tgz
+COVBIN=$(echo $(pwd)/cov-analysis*/bin)
+export PATH=$COVBIN:$PATH
+popd
+
+cd libs/$SELF/test
+../../../b2 toolset=gcc clean
+rm -rf cov-int/
+cov-build --dir cov-int ../../../b2 toolset=gcc -q -j3
+tar cJf cov-int.tar.xz cov-int/
+curl --form token="$COVERITY_SCAN_TOKEN" \
+     --form email="$COVERITY_SCAN_NOTIFICATION_EMAIL" \
+     --form file=@cov-int.tar.xz \
+     --form version="$(git describe --tags)" \
+     --form description="boostorg/$SELF" \
+     https://scan.coverity.com/builds?project="boostorg/$SELF"


### PR DESCRIPTION
I also converted the .travis.yml file from matrix to job processing, it's cleaner