### PR TITLE
Switch WINAPI calling convention macros to the replacements from Boost.WinAPI

### DIFF
--- a/test/mock_random.cpp
+++ b/test/mock_random.cpp
@@ -56,7 +56,7 @@ BOOST_SYMBOL_EXPORT bool provider_acquires_context()
 extern "C" {
 
 BOOST_SYMBOL_EXPORT
-boost::winapi::BOOL_ WINAPI
+boost::winapi::BOOL_ BOOST_WINAPI_WINAPI_CC
 CryptAcquireContextW(
     boost::winapi::HCRYPTPROV_ *phProv,
     boost::winapi::LPCWSTR_ szContainer,
@@ -76,7 +76,7 @@ CryptAcquireContextW(
 }
 
 BOOST_SYMBOL_EXPORT
-boost::winapi::BOOL_ WINAPI
+boost::winapi::BOOL_ BOOST_WINAPI_WINAPI_CC
 CryptGenRandom(
     boost::winapi::HCRYPTPROV_ hProv,
     boost::winapi::DWORD_ dwLen,
@@ -94,7 +94,7 @@ CryptGenRandom(
 // the implementation ignores the result of close because it
 // happens in a destructor
 BOOST_SYMBOL_EXPORT
-boost::winapi::BOOL_ WINAPI
+boost::winapi::BOOL_ BOOST_WINAPI_WINAPI_CC
 CryptReleaseContext(
     boost::winapi::HCRYPTPROV_ hProv,
 #if defined(_MSC_VER) && (_MSC_VER+0) >= 1500 && (_MSC_VER+0) < 1900 && BOOST_USE_NTDDI_VERSION < BOOST_WINAPI_NTDDI_WINXP

--- a/test/mock_random.hpp
+++ b/test/mock_random.hpp
@@ -88,7 +88,7 @@ bool provider_acquires_context()
     return true;
 }
 
-boost::winapi::NTSTATUS_ WINAPI
+boost::winapi::NTSTATUS_ BOOST_WINAPI_WINAPI_CC
 BCryptOpenAlgorithmProvider(
     boost::winapi::BCRYPT_ALG_HANDLE_ *phAlgorithm,
     boost::winapi::LPCWSTR_           pszAlgId,
@@ -106,7 +106,7 @@ BCryptOpenAlgorithmProvider(
     return result;
 }
 
-boost::winapi::NTSTATUS_ WINAPI
+boost::winapi::NTSTATUS_ BOOST_WINAPI_WINAPI_CC
 BCryptGenRandom(
     boost::winapi::BCRYPT_ALG_HANDLE_ hAlgorithm,
     boost::winapi::PUCHAR_            pbBuffer,
@@ -126,7 +126,7 @@ BCryptGenRandom(
 
 // the implementation ignores the result of close because it
 // happens in a destructor
-boost::winapi::NTSTATUS_ WINAPI
+boost::winapi::NTSTATUS_ BOOST_WINAPI_WINAPI_CC
 BCryptCloseAlgorithmProvider(
     boost::winapi::BCRYPT_ALG_HANDLE_ hAlgorithm,
     boost::winapi::ULONG_             dwFlags


### PR DESCRIPTION
WINAPI macro definition in Boost.WinAPI is deprecated as it may clash with the macro defined in Windows SDK.