### PR TITLE
Add support for movability to random generators. Fix POSIX random provider

### DIFF
--- a/include/boost/uuid/detail/random_provider.hpp
+++ b/include/boost/uuid/detail/random_provider.hpp
@@ -11,10 +11,12 @@
 #ifndef BOOST_UUID_DETAIL_RANDOM_PROVIDER_HPP
 #define BOOST_UUID_DETAIL_RANDOM_PROVIDER_HPP
 
-#include <boost/core/noncopyable.hpp>
+#include <boost/config.hpp>
 #include <boost/cstdint.hpp>
 #include <boost/limits.hpp>
 #include <boost/static_assert.hpp>
+#include <boost/move/core.hpp>
+#include <boost/move/utility_core.hpp>
 #include <boost/type_traits/is_integral.hpp>
 #include <boost/type_traits/is_unsigned.hpp>
 #include <boost/uuid/entropy_error.hpp>
@@ -38,11 +40,25 @@ namespace detail {
 //! \note  noncopyable because of some base implementations so
 //!        this makes it uniform across platforms to avoid any  
 //!        porting surprises
-class random_provider
-    : public detail::random_provider_base,
-      public noncopyable
+class random_provider :
+    public detail::random_provider_base
 {
+    BOOST_MOVABLE_BUT_NOT_COPYABLE(random_provider)
+
 public:
+    BOOST_DEFAULTED_FUNCTION(random_provider(), {})
+
+    random_provider(BOOST_RV_REF(random_provider) that) BOOST_NOEXCEPT :
+        detail::random_provider_base(boost::move(static_cast< detail::random_provider_base& >(that)))
+    {
+    }
+
+    random_provider& operator= (BOOST_RV_REF(random_provider) that) BOOST_NOEXCEPT
+    {
+        static_cast< detail::random_provider_base& >(*this) = boost::move(static_cast< detail::random_provider_base& >(that));
+        return *this;
+    }
+
     //! Leverage the provider as a SeedSeq for
     //! PseudoRandomNumberGeneration seeing.
     //! \note: See Boost.Random documentation for more details

--- a/include/boost/uuid/detail/random_provider_arc4random.ipp
+++ b/include/boost/uuid/detail/random_provider_arc4random.ipp
@@ -9,7 +9,8 @@
 // https://man.openbsd.org/arc4random.3
 //
 
-#include <stdlib.h> 
+#include <cstddef>
+#include <stdlib.h>
 
 namespace boost {
 namespace uuids {
@@ -21,7 +22,7 @@ class random_provider_base
     //! Obtain entropy and place it into a memory location
     //! \param[in]  buf  the location to write entropy
     //! \param[in]  siz  the number of bytes to acquire
-    void get_random_bytes(void *buf, size_t siz)
+    void get_random_bytes(void *buf, std::size_t siz)
     {
         arc4random_buf(buf, siz);
     }

--- a/include/boost/uuid/detail/random_provider_bcrypt.ipp
+++ b/include/boost/uuid/detail/random_provider_bcrypt.ipp
@@ -8,7 +8,10 @@
 // BCrypt provider for entropy
 //
 
+#include <cstddef>
+#include <boost/config.hpp>
 #include <boost/core/ignore_unused.hpp>
+#include <boost/move/core.hpp>
 #include <boost/numeric/conversion/cast.hpp>
 #include <boost/winapi/bcrypt.hpp>
 #include <boost/winapi/get_last_error.hpp>
@@ -27,7 +30,9 @@ namespace detail {
 
 class random_provider_base
 {
-  public:
+    BOOST_MOVABLE_BUT_NOT_COPYABLE(random_provider_base)
+
+public:
     random_provider_base()
       : hProv_(NULL)
     {
@@ -38,24 +43,34 @@ class random_provider_base
                 NULL,
                 0);
 
-        if (status)
+        if (BOOST_UNLIKELY(status != 0))
         {
             BOOST_THROW_EXCEPTION(entropy_error(status, "BCryptOpenAlgorithmProvider"));
         }
     }
 
+    random_provider_base(BOOST_RV_REF(random_provider_base) that) BOOST_NOEXCEPT : hProv_(that.hProv_)
+    {
+        that.hProv_ = NULL;
+    }
+
+    random_provider_base& operator= (BOOST_RV_REF(random_provider_base) that) BOOST_NOEXCEPT
+    {
+        destroy();
+        hProv_ = that.hProv_;
+        that.hProv_ = NULL;
+        return *this;
+    }
+
     ~random_provider_base() BOOST_NOEXCEPT
     {
-        if (hProv_)
-        {
-            ignore_unused(boost::winapi::BCryptCloseAlgorithmProvider(hProv_, 0));
-        }
+        destroy();
     }
 
     //! Obtain entropy and place it into a memory location
     //! \param[in]  buf  the location to write entropy
     //! \param[in]  siz  the number of bytes to acquire
-    void get_random_bytes(void *buf, size_t siz)
+    void get_random_bytes(void *buf, std::size_t siz)
     {
         boost::winapi::NTSTATUS_ status =
             boost::winapi::BCryptGenRandom(
@@ -64,13 +79,22 @@ class random_provider_base
                 boost::numeric_cast<boost::winapi::ULONG_>(siz),
                 0);
 
-        if (status)
+        if (BOOST_UNLIKELY(status != 0))
         {
             BOOST_THROW_EXCEPTION(entropy_error(status, "BCryptGenRandom"));
         }
     }
 
-  private:
+private:
+    void destroy() BOOST_NOEXCEPT
+    {
+        if (hProv_)
+        {
+            boost::ignore_unused(boost::winapi::BCryptCloseAlgorithmProvider(hProv_, 0));
+        }
+    }
+
+private:
     boost::winapi::BCRYPT_ALG_HANDLE_ hProv_;
 };
 

--- a/include/boost/uuid/detail/random_provider_getentropy.ipp
+++ b/include/boost/uuid/detail/random_provider_getentropy.ipp
@@ -8,8 +8,10 @@
 // getentropy() capable platforms
 //
 
+#include <boost/config.hpp>
 #include <boost/throw_exception.hpp>
 #include <cerrno>
+#include <cstddef>
 #include <unistd.h>
 
 namespace boost {
@@ -18,13 +20,14 @@ namespace detail {
 
 class random_provider_base
 {
-  public:
+public:
     //! Obtain entropy and place it into a memory location
     //! \param[in]  buf  the location to write entropy
     //! \param[in]  siz  the number of bytes to acquire
-    void get_random_bytes(void *buf, size_t siz)
+    void get_random_bytes(void *buf, std::size_t siz)
     {
-        if (-1 == getentropy(buf, siz))
+        int res = getentropy(buf, siz);
+        if (BOOST_UNLIKELY(-1 == res))
         {
             int err = errno;
             BOOST_THROW_EXCEPTION(entropy_error(err, "getentropy"));

--- a/include/boost/uuid/detail/random_provider_posix.ipp
+++ b/include/boost/uuid/detail/random_provider_posix.ipp
@@ -12,10 +12,13 @@
 * $Id$
 */
 
+#include <boost/config.hpp>
 #include <boost/core/ignore_unused.hpp>
+#include <boost/move/core.hpp>
 #include <boost/throw_exception.hpp>
 #include <boost/uuid/entropy_error.hpp>
 #include <cerrno>
+#include <cstddef>
 #include <fcntl.h>    // open
 #include <sys/stat.h>
 #include <sys/types.h>
@@ -39,9 +42,11 @@ namespace detail {
 
 class random_provider_base
 {
-  public:
+    BOOST_MOVABLE_BUT_NOT_COPYABLE(random_provider_base)
+
+public:
     random_provider_base()
-      : fd_(0)
+      : fd_(-1)
     {
         int flags = O_RDONLY;
 #if defined(O_CLOEXEC)
@@ -49,44 +54,64 @@ class random_provider_base
 #endif
         fd_ = BOOST_UUID_RANDOM_PROVIDER_POSIX_IMPL_OPEN("/dev/urandom", flags);
 
-        if (-1 == fd_)
+        if (BOOST_UNLIKELY(-1 == fd_))
         {
             int err = errno;
             BOOST_THROW_EXCEPTION(entropy_error(err, "open /dev/urandom"));
         }
     }
 
+    random_provider_base(BOOST_RV_REF(random_provider_base) that) BOOST_NOEXCEPT : fd_(that.fd_)
+    {
+        that.fd_ = -1;
+    }
+
+    random_provider_base& operator= (BOOST_RV_REF(random_provider_base) that) BOOST_NOEXCEPT
+    {
+        destroy();
+        fd_ = that.fd_;
+        that.fd_ = -1;
+        return *this;
+    }
+
     ~random_provider_base() BOOST_NOEXCEPT
     {
-        if (fd_)
-        {
-            ignore_unused(BOOST_UUID_RANDOM_PROVIDER_POSIX_IMPL_CLOSE(fd_));
-        }
+        destroy();
     }
 
     //! Obtain entropy and place it into a memory location
     //! \param[in]  buf  the location to write entropy
     //! \param[in]  siz  the number of bytes to acquire
-    void get_random_bytes(void *buf, size_t siz)
+    void get_random_bytes(void *buf, std::size_t siz)
     {
-        size_t offset = 0;
-        do
+        std::size_t offset = 0;
+        while (offset < siz)
         {
             ssize_t sz = BOOST_UUID_RANDOM_PROVIDER_POSIX_IMPL_READ(
                 fd_, static_cast<char *>(buf) + offset, siz - offset);
 
-            if (sz < 1)
+            if (BOOST_UNLIKELY(sz < 0))
             {
                 int err = errno;
+                if (err == EINTR)
+                    continue;
                 BOOST_THROW_EXCEPTION(entropy_error(err, "read"));
             }
 
             offset += sz;
-
-        } while (offset < siz);
+        }
     }
 
-  private:
+private:
+    void destroy() BOOST_NOEXCEPT
+    {
+        if (fd_ >= 0)
+        {
+            boost::ignore_unused(BOOST_UUID_RANDOM_PROVIDER_POSIX_IMPL_CLOSE(fd_));
+        }
+    }
+
+private:
     int fd_;
 };
 

--- a/include/boost/uuid/detail/random_provider_wincrypt.ipp
+++ b/include/boost/uuid/detail/random_provider_wincrypt.ipp
@@ -12,7 +12,10 @@
 * $Id$
 */
 
+#include <cstddef>
+#include <boost/config.hpp>
 #include <boost/core/ignore_unused.hpp>
+#include <boost/move/core.hpp>
 #include <boost/numeric/conversion/cast.hpp>
 #include <boost/winapi/crypt.hpp>
 #include <boost/winapi/get_last_error.hpp>
@@ -35,45 +38,69 @@ namespace detail {
 
 class random_provider_base
 {
-  public:
+    BOOST_MOVABLE_BUT_NOT_COPYABLE(random_provider_base)
+
+public:
     random_provider_base()
         : hProv_(0)
     {
-        if (!boost::winapi::CryptAcquireContextW(
+        boost::winapi::BOOL_ res = boost::winapi::CryptAcquireContextW(
             &hProv_,
             NULL,
             NULL,
             boost::winapi::PROV_RSA_FULL_,
-            boost::winapi::CRYPT_VERIFYCONTEXT_ | boost::winapi::CRYPT_SILENT_))
+            boost::winapi::CRYPT_VERIFYCONTEXT_ | boost::winapi::CRYPT_SILENT_);
+        if (BOOST_UNLIKELY(!res))
         {
             boost::winapi::DWORD_ err = boost::winapi::GetLastError();
             BOOST_THROW_EXCEPTION(entropy_error(err, "CryptAcquireContext"));
         }
     }
 
+    random_provider_base(BOOST_RV_REF(random_provider_base) that) BOOST_NOEXCEPT : hProv_(that.hProv_)
+    {
+        that.hProv_ = 0;
+    }
+
+    random_provider_base& operator= (BOOST_RV_REF(random_provider_base) that) BOOST_NOEXCEPT
+    {
+        destroy();
+        hProv_ = that.hProv_;
+        that.hProv_ = 0;
+        return *this;
+    }
+
     ~random_provider_base() BOOST_NOEXCEPT
     {
-        if (hProv_)
-        {
-            ignore_unused(boost::winapi::CryptReleaseContext(hProv_, 0));
-        }
+        destroy();
     }
 
     //! Obtain entropy and place it into a memory location
     //! \param[in]  buf  the location to write entropy
     //! \param[in]  siz  the number of bytes to acquire
-    void get_random_bytes(void *buf, size_t siz)
+    void get_random_bytes(void *buf, std::size_t siz)
     {
-        if (!boost::winapi::CryptGenRandom(hProv_, 
-                    boost::numeric_cast<boost::winapi::DWORD_>(siz), 
-                    static_cast<boost::winapi::BYTE_ *>(buf)))
+        boost::winapi::BOOL_ res = boost::winapi::CryptGenRandom(
+            hProv_,
+            boost::numeric_cast<boost::winapi::DWORD_>(siz),
+            static_cast<boost::winapi::BYTE_ *>(buf));
+        if (BOOST_UNLIKELY(!res))
         {
             boost::winapi::DWORD_ err = boost::winapi::GetLastError();
             BOOST_THROW_EXCEPTION(entropy_error(err, "CryptGenRandom"));
         }
     }
 
-  private:
+private:
+    void destroy() BOOST_NOEXCEPT
+    {
+        if (hProv_)
+        {
+            boost::ignore_unused(boost::winapi::CryptReleaseContext(hProv_, 0));
+        }
+    }
+
+private:
     boost::winapi::HCRYPTPROV_ hProv_;
 };
 

--- a/include/boost/uuid/random_generator.hpp
+++ b/include/boost/uuid/random_generator.hpp
@@ -9,13 +9,14 @@
 #ifndef BOOST_UUID_RANDOM_GENERATOR_HPP
 #define BOOST_UUID_RANDOM_GENERATOR_HPP
 
+#include <boost/config.hpp>
 #include <boost/assert.hpp>
+#include <boost/move/core.hpp>
+#include <boost/move/utility_core.hpp>
 #include <boost/core/enable_if.hpp>
-#include <boost/core/null_deleter.hpp>
 #include <boost/random/mersenne_twister.hpp>
 #include <boost/random/uniform_int.hpp>
 #include <boost/random/variate_generator.hpp>
-#include <boost/shared_ptr.hpp>
 #include <boost/tti/has_member_function.hpp>
 #include <boost/uuid/detail/random_provider.hpp>
 #include <boost/uuid/uuid.hpp>
@@ -40,17 +41,59 @@ namespace detail {
 
         return u;
     }
-    
+
     BOOST_TTI_HAS_MEMBER_FUNCTION(seed)
 }
 
 //! generate a random-based uuid
 //! \param[in]  UniformRandomNumberGenerator  see Boost.Random documentation
 template <typename UniformRandomNumberGenerator>
-class basic_random_generator {
+class basic_random_generator
+{
+    BOOST_MOVABLE_BUT_NOT_COPYABLE(basic_random_generator)
+
 private:
     typedef uniform_int<unsigned long> distribution_type;
     typedef variate_generator<UniformRandomNumberGenerator*, distribution_type> generator_type;
+
+    struct impl
+    {
+        generator_type generator;
+
+        explicit impl(UniformRandomNumberGenerator* purng_arg) :
+            generator(purng_arg, distribution_type((std::numeric_limits<unsigned long>::min)(), (std::numeric_limits<unsigned long>::max)()))
+        {
+        }
+
+        virtual ~impl() {}
+
+        BOOST_DELETED_FUNCTION(impl(impl const&))
+        BOOST_DELETED_FUNCTION(impl& operator= (impl const&))
+    };
+
+    struct urng_holder
+    {
+        UniformRandomNumberGenerator urng;
+    };
+
+#if defined(BOOST_MSVC)
+#pragma warning(push)
+// 'this' : used in base member initializer list
+#pragma warning(disable: 4355)
+#endif
+
+    struct self_contained_impl :
+        public urng_holder,
+        public impl
+    {
+        self_contained_impl() : impl(&this->urng_holder::urng)
+        {
+        }
+    };
+
+#if defined(BOOST_MSVC)
+#pragma warning(pop)
+#endif
 
 public:
     typedef uuid result_type;
@@ -58,46 +101,41 @@ public:
     // default constructor creates the random number generator and
     // if the UniformRandomNumberGenerator is a PseudoRandomNumberGenerator
     // then it gets seeded by a random_provider.
-    basic_random_generator()
-        : pURNG(new UniformRandomNumberGenerator)
-        , generator
-          ( pURNG.get()
-          , distribution_type
-            ( (std::numeric_limits<unsigned long>::min)()
-            , (std::numeric_limits<unsigned long>::max)()
-            )
-          )
+    basic_random_generator() : m_impl(new self_contained_impl())
     {
         // seed the random number generator if it is capable
-        seed(*pURNG);
+        seed(static_cast< self_contained_impl* >(m_impl)->urng);
     }
 
     // keep a reference to a random number generator
     // don't seed a given random number generator
-    explicit basic_random_generator(UniformRandomNumberGenerator& gen)
-        : pURNG(&gen, boost::null_deleter())
-        , generator
-          ( pURNG.get()
-          , distribution_type
-            ( (std::numeric_limits<unsigned long>::min)()
-            , (std::numeric_limits<unsigned long>::max)()
-            )
-          )
-    {}
+    explicit basic_random_generator(UniformRandomNumberGenerator& gen) : m_impl(new impl(&gen))
+    {
+    }
 
     // keep a pointer to a random number generator
     // don't seed a given random number generator
-    explicit basic_random_generator(UniformRandomNumberGenerator* pGen)
-        : pURNG(pGen, boost::null_deleter())
-        , generator
-          ( pURNG.get()
-          , distribution_type
-            ( (std::numeric_limits<unsigned long>::min)()
-            , (std::numeric_limits<unsigned long>::max)()
-            )
-          )
+    explicit basic_random_generator(UniformRandomNumberGenerator* gen) : m_impl(new impl(gen))
     {
-        BOOST_ASSERT(pURNG);
+        BOOST_ASSERT(!!gen);
+    }
+
+    basic_random_generator(BOOST_RV_REF(basic_random_generator) that) BOOST_NOEXCEPT : m_impl(that.m_impl)
+    {
+        that.m_impl = 0;
+    }
+
+    basic_random_generator& operator= (BOOST_RV_REF(basic_random_generator) that) BOOST_NOEXCEPT
+    {
+        delete m_impl;
+        m_impl = that.m_impl;
+        that.m_impl = 0;
+        return *this;
+    }
+
+    ~basic_random_generator()
+    {
+        delete m_impl;
     }
 
     result_type operator()()
@@ -105,10 +143,10 @@ public:
         result_type u;
 
         int i=0;
-        unsigned long random_value = generator();
-        for (uuid::iterator it=u.begin(); it!=u.end(); ++it, ++i) {
+        unsigned long random_value = m_impl->generator();
+        for (uuid::iterator it = u.begin(), end = u.end(); it != end; ++it, ++i) {
             if (i==sizeof(unsigned long)) {
-                random_value = generator();
+                random_value = m_impl->generator();
                 i = 0;
             }
 
@@ -139,8 +177,7 @@ private:
     {
     }
 
-    shared_ptr<UniformRandomNumberGenerator> pURNG;
-    generator_type generator;
+    impl* m_impl;
 };
 
 //! \brief a far less complex random generator that uses
@@ -148,8 +185,23 @@ private:
 //!        satisfy the majority of use cases
 class random_generator_pure
 {
+    BOOST_MOVABLE_BUT_NOT_COPYABLE(random_generator_pure)
+
 public:
     typedef uuid result_type;
+
+    BOOST_DEFAULTED_FUNCTION(random_generator_pure(), {})
+
+    random_generator_pure(BOOST_RV_REF(random_generator_pure) that) BOOST_NOEXCEPT :
+        prov_(boost::move(that.prov_))
+    {
+    }
+
+    random_generator_pure& operator= (BOOST_RV_REF(random_generator_pure) that) BOOST_NOEXCEPT
+    {
+        prov_ = boost::move(that.prov_);
+        return *this;
+    }
 
     //! \returns a random, valid uuid
     //! \throws entropy_error

--- a/test/Jamfile.v2
+++ b/test/Jamfile.v2
@@ -51,6 +51,16 @@ rule test_all
         all_rules += [ compile compile/decl_header.cpp : <define>"BOOST_UUID_TEST_HEADER=$(rel_file)" <dependency>$(file) : $(decl_test_name) ] ;
     }
 
+    local tests_path = [ path.make $(BOOST_ROOT)/libs/uuid/test/compile-fail ] ;
+    for file in [ path.glob-tree $(tests_path) : *.cpp ]
+    {
+        local rel_file = [ path.relative-to $(tests_path) $(file) ] ;
+        local test_name = [ regex.replace [ regex.replace $(rel_file) "/" "-" ] ".cpp" "" ] ;
+        local decl_test_name = cf-$(test_name) ;
+        # ECHO $(rel_file) ;
+        all_rules += [ compile-fail $(file) : : $(decl_test_name) ] ;
+    }
+
     # make sure compile time options work in isolation
     all_rules += [ compile compile/decl_header.cpp :
         <define>"BOOST_UUID_TEST_HEADER=uuid.hpp"

--- a/test/compile-fail/basic_random_generator_no_copy_assign.cpp
+++ b/test/compile-fail/basic_random_generator_no_copy_assign.cpp
@@ -1,0 +1,18 @@
+// (c) Copyright Andrey Semashev 2018
+
+// Distributed under the Boost Software License, Version 1.0. (See
+// accompanying file LICENSE_1_0.txt or copy at
+// http://www.boost.org/LICENSE_1_0.txt)
+
+// The test verifies that basic_random_generator is not copy assignable
+
+#include <boost/uuid/random_generator.hpp>
+#include <boost/random/linear_congruential.hpp>
+
+int main()
+{
+    boost::uuids::basic_random_generator<boost::rand48> uuid_gen1, uuid_gen2;
+    uuid_gen2 = uuid_gen1;
+
+    return 1;
+}

--- a/test/compile-fail/basic_random_generator_no_copy_ctor.cpp
+++ b/test/compile-fail/basic_random_generator_no_copy_ctor.cpp
@@ -1,0 +1,18 @@
+// (c) Copyright Andrey Semashev 2018
+
+// Distributed under the Boost Software License, Version 1.0. (See
+// accompanying file LICENSE_1_0.txt or copy at
+// http://www.boost.org/LICENSE_1_0.txt)
+
+// The test verifies that basic_random_generator is not copy constructible
+
+#include <boost/uuid/random_generator.hpp>
+#include <boost/random/linear_congruential.hpp>
+
+int main()
+{
+    boost::uuids::basic_random_generator<boost::rand48> uuid_gen1;
+    boost::uuids::basic_random_generator<boost::rand48> uuid_gen2(uuid_gen1);
+
+    return 1;
+}

--- a/test/compile-fail/random_generator_no_copy_assign.cpp
+++ b/test/compile-fail/random_generator_no_copy_assign.cpp
@@ -1,0 +1,17 @@
+// (c) Copyright Andrey Semashev 2018
+
+// Distributed under the Boost Software License, Version 1.0. (See
+// accompanying file LICENSE_1_0.txt or copy at
+// http://www.boost.org/LICENSE_1_0.txt)
+
+// The test verifies that random_generator is not copy assignable
+
+#include <boost/uuid/random_generator.hpp>
+
+int main()
+{
+    boost::uuids::random_generator uuid_gen1, uuid_gen2;
+    uuid_gen2 = uuid_gen1;
+
+    return 1;
+}

--- a/test/compile-fail/random_generator_no_copy_ctor.cpp
+++ b/test/compile-fail/random_generator_no_copy_ctor.cpp
@@ -1,0 +1,17 @@
+// (c) Copyright Andrey Semashev 2018
+
+// Distributed under the Boost Software License, Version 1.0. (See
+// accompanying file LICENSE_1_0.txt or copy at
+// http://www.boost.org/LICENSE_1_0.txt)
+
+// The test verifies that random_generator is not copy constructible
+
+#include <boost/uuid/random_generator.hpp>
+
+int main()
+{
+    boost::uuids::random_generator uuid_gen1;
+    boost::uuids::random_generator uuid_gen2(uuid_gen1);
+
+    return 1;
+}

--- a/test/mock_random.hpp
+++ b/test/mock_random.hpp
@@ -228,7 +228,7 @@ ssize_t mockread(int fd, void *buf, size_t siz)
 
     bool success = posix_next_result.front();
     posix_next_result.pop_front();
-    return success ? 1 : 0;
+    return success ? 1 : -1;
 }
 
 #define BOOST_UUID_RANDOM_PROVIDER_POSIX_IMPL_OPEN mockopen

--- a/test/test_generators.cpp
+++ b/test/test_generators.cpp
@@ -46,7 +46,7 @@ int test_main(int, char*[])
         uuid u3 = nil_uuid();
         BOOST_CHECK_EQUAL(u3, u2);
     }
-    
+
     { // test string_generator
         string_generator gen;
         uuid u = gen("00000000-0000-0000-0000-000000000000");
@@ -58,7 +58,7 @@ int test_main(int, char*[])
 
         u = gen("0123456789abcdef0123456789ABCDEF");
         BOOST_CHECK_EQUAL(u, u_increasing);
-        
+
         u = gen("{0123456789abcdef0123456789ABCDEF}");
         BOOST_CHECK_EQUAL(u, u_increasing);
 
@@ -67,7 +67,7 @@ int test_main(int, char*[])
 
         u = gen("01234567-89AB-CDEF-0123-456789abcdef");
         BOOST_CHECK_EQUAL(u, u_increasing);
-        
+
         u = gen(std::string("fedcba98-7654-3210-fedc-ba9876543210"));
         BOOST_CHECK_EQUAL(u, u_decreasing);
 
@@ -79,7 +79,7 @@ int test_main(int, char*[])
         BOOST_CHECK_EQUAL(u, u_increasing);
 #endif //BOOST_NO_STD_WSTRING
     }
-    
+
     { // test name_generator
         uuid dns_namespace_uuid = {{0x6b, 0xa7, 0xb8, 0x10, 0x9d, 0xad, 0x11, 0xd1, 0x80, 0xb4, 0x00, 0xc0, 0x4f, 0xd4, 0x30, 0xc8}};
         uuid correct = {{0x21, 0xf7, 0xf8, 0xde, 0x80, 0x51, 0x5b, 0x89, 0x86, 0x80, 0x01, 0x95, 0xef, 0x79, 0x8b, 0x6a}};
@@ -113,16 +113,16 @@ int test_main(int, char*[])
         // default random number generator
         random_generator uuid_gen1;
         check_random_generator(uuid_gen1);
-        
+
         // specific random number generator
         basic_random_generator<boost::rand48> uuid_gen2;
         check_random_generator(uuid_gen2);
-        
+
         // pass by reference
         boost::ecuyer1988 ecuyer1988_gen;
         basic_random_generator<boost::ecuyer1988> uuid_gen3(ecuyer1988_gen);
         check_random_generator(uuid_gen3);
-        
+
         // pass by pointer
         boost::lagged_fibonacci607 lagged_fibonacci607_gen;
         basic_random_generator<boost::lagged_fibonacci607> uuid_gen4(&lagged_fibonacci607_gen);
@@ -132,6 +132,6 @@ int test_main(int, char*[])
         //basic_random_generator<boost::random_device> uuid_gen5;
         //check_random_generator(uuid_gen5);
     }
-    
+
     return 0;
 }

--- a/test/test_random_generator.cpp
+++ b/test/test_random_generator.cpp
@@ -17,6 +17,7 @@
 #include <boost/uuid/random_generator.hpp>
 #include <boost/uuid/uuid_io.hpp>
 #include <boost/uuid/uuid.hpp>
+#include <boost/move/utility_core.hpp>
 
 template <typename RandomUuidGenerator>
 void check_random_generator(RandomUuidGenerator& uuid_gen)
@@ -85,6 +86,30 @@ int main(int, char*[])
     boost::lagged_fibonacci607 lagged_fibonacci607_gen;
     basic_random_generator<boost::lagged_fibonacci607> uuid_gen4(&lagged_fibonacci607_gen);
     check_random_generator(uuid_gen4);
+
+    // check move construction
+    {
+        random_generator uuid_gen1;
+        random_generator uuid_gen2(boost::move(uuid_gen1));
+        boost::ignore_unused(uuid_gen2);
+    }
+    {
+        basic_random_generator<boost::rand48> uuid_gen1;
+        basic_random_generator<boost::rand48> uuid_gen2(boost::move(uuid_gen1));
+        boost::ignore_unused(uuid_gen2);
+    }
+
+    // check move assignment
+    {
+        random_generator uuid_gen1, uuid_gen2;
+        uuid_gen2 = boost::move(uuid_gen1);
+        boost::ignore_unused(uuid_gen2);
+    }
+    {
+        basic_random_generator<boost::rand48> uuid_gen1, uuid_gen2;
+        uuid_gen2 = boost::move(uuid_gen1);
+        boost::ignore_unused(uuid_gen2);
+    }
 
     // there was a bug in basic_random_generator where it did not
     // produce very random numbers.  This checks for that bug.


### PR DESCRIPTION
The commit adds support for move constructors and assignment to random UUID
generators and random providers. Also, in POSIX random provider, the commit
improves handling of return value from ::read(), which returns -1
in case of error and may return 0 in case of success. Retry the call when
it was interrupted before reading any bytes from /dev/urandom.

Added new tests for movability.

This fixes #71