### PR TITLE
Add support for Linux-specific getrandom call to obtain random data.

### DIFF
--- a/doc/uuid.html
+++ b/doc/uuid.html
@@ -608,7 +608,7 @@ public:
     result_type operator()();
 };
 
-    typedef basic_random_generator&lt;boost::mt19937&gt; random_generator_mt19937;
+typedef basic_random_generator&lt;boost::mt19937&gt; random_generator_mt19937;
 
 }} // namespace boost::uuids
 </pre>
@@ -642,13 +642,14 @@ public:
             <li>CloudABI</li>
             <li>Unix
                 <ul>
-                    <li>OpenBSD: <tt>use <a href="https://man.openbsd.org/arc4random.3">arc4random(3)</a></tt></li>
-                    <li>Linux with glibc 2.25 or later: use <tt>getentropy(3)</tt></li>
+                    <li>OpenBSD: use <a href="https://man.openbsd.org/arc4random.3"><tt>arc4random(3)</tt></a></li>
+                    <li>Linux 3.17 or later: use <a href="http://man7.org/linux/man-pages/man2/getrandom.2.html"><tt>getrandom(2)</tt></a></li>
+                    <li>Other systems with glibc 2.25 or later: use <tt>getentropy(3)</tt></li>
                     <li>All other cases: use <tt>/dev/urandom</tt></li>
                 </ul>
             </li>
             <li>Windows (UWP Compatible): use BCrypt if available, otherwise use Wincrypt
-</ul>
+        </ul>
     </p>
 
 <h5>Preprocessor Macros</h5>
@@ -656,7 +657,7 @@ public:
         <ul>
             <li>
                 <tt>BOOST_UUID_RANDOM_PROVIDER_FORCE_POSIX</tt>: on Unix this will force the
-                selection of <tt>/dev/*random</tt> over <tt>getentropy(3)</tt>.
+                selection of <tt>/dev/*random</tt> over <tt>getrandom(2)</tt> or <tt>getentropy(3)</tt>.
             </li>
             <li>
                 <tt>BOOST_UUID_RANDOM_PROVIDER_FORCE_WINCRYPT</tt>: on Windows this will force the

--- a/include/boost/uuid/detail/random_provider_detect_platform.hpp
+++ b/include/boost/uuid/detail/random_provider_detect_platform.hpp
@@ -14,7 +14,11 @@
 #include <boost/predef/library/c/cloudabi.h>
 #include <boost/predef/library/c/gnu.h>
 #include <boost/predef/os/bsd/open.h>
+#include <boost/predef/os/linux.h>
 #include <boost/predef/os/windows.h>
+#if BOOST_OS_LINUX
+#include <sys/syscall.h>
+#endif
 
 //
 // Platform Detection - will load in the correct header and
@@ -40,6 +44,10 @@
 # else
 #  error Unable to find a suitable windows entropy provider
 # endif
+
+#elif BOOST_OS_LINUX && defined(SYS_getrandom) && !defined(BOOST_UUID_RANDOM_PROVIDER_FORCE_POSIX) && !defined(BOOST_UUID_RANDOM_PROVIDER_DISABLE_GETRANDOM)
+# define BOOST_UUID_RANDOM_PROVIDER_GETRANDOM
+# define BOOST_UUID_RANDOM_PROVIDER_NAME getrandom
 
 #elif BOOST_LIB_C_GNU >= BOOST_VERSION_NUMBER(2, 25, 0) && !defined(BOOST_UUID_RANDOM_PROVIDER_FORCE_POSIX)
 # define BOOST_UUID_RANDOM_PROVIDER_GETENTROPY

--- a/include/boost/uuid/detail/random_provider_getrandom.ipp
+++ b/include/boost/uuid/detail/random_provider_getrandom.ipp
@@ -1,0 +1,77 @@
+//
+// Copyright (c) 2018 Andrey Semashev
+//
+// Distributed under the Boost Software License, Version 1.0.
+// (See accompanying file LICENSE_1_0.txt or copy at
+//   http://www.boost.org/LICENCE_1_0.txt)
+//
+// getrandom() capable platforms
+//
+
+#include <boost/config.hpp>
+#include <boost/throw_exception.hpp>
+#include <boost/predef/library/c/gnu.h>
+#include <cerrno>
+#include <cstddef>
+
+#if !defined(BOOST_UUID_RANDOM_PROVIDER_GETRANDOM_IMPL_GETRANDOM)
+#if BOOST_LIB_C_GNU >= BOOST_VERSION_NUMBER(2, 25, 0)
+#define BOOST_UUID_RANDOM_PROVIDER_GETRANDOM_HAS_LIBC_WRAPPER
+#elif defined(__has_include)
+#if __has_include(<sys/random.h>)
+#define BOOST_UUID_RANDOM_PROVIDER_GETRANDOM_HAS_LIBC_WRAPPER
+#endif
+#endif
+#endif // !defined(BOOST_UUID_RANDOM_PROVIDER_GETRANDOM_IMPL_GETRANDOM)
+
+#if defined(BOOST_UUID_RANDOM_PROVIDER_GETRANDOM_HAS_LIBC_WRAPPER)
+#include <sys/random.h>
+#else
+#include <stddef.h> // ssize_t
+#endif
+
+namespace boost {
+namespace uuids {
+namespace detail {
+
+class random_provider_base
+{
+public:
+    //! Obtain entropy and place it into a memory location
+    //! \param[in]  buf  the location to write entropy
+    //! \param[in]  siz  the number of bytes to acquire
+    void get_random_bytes(void *buf, std::size_t siz)
+    {
+        std::size_t offset = 0;
+        while (offset < siz)
+        {
+            ssize_t sz = get_random(static_cast< char* >(buf) + offset, siz - offset, 0u);
+
+            if (BOOST_UNLIKELY(sz < 0))
+            {
+                int err = errno;
+                if (err == EINTR)
+                    continue;
+                BOOST_THROW_EXCEPTION(entropy_error(err, "getrandom"));
+            }
+
+            offset += sz;
+        }
+    }
+
+private:
+    static ssize_t get_random(void *buf, std::size_t size, unsigned int flags)
+    {
+#if defined(BOOST_UUID_RANDOM_PROVIDER_GETRANDOM_IMPL_GETRANDOM)
+        return BOOST_UUID_RANDOM_PROVIDER_GETRANDOM_IMPL_GETRANDOM(buf, size, flags);
+#elif defined(BOOST_UUID_RANDOM_PROVIDER_GETRANDOM_HAS_LIBC_WRAPPER)
+        return ::getrandom(buf, size, flags);
+#else
+        return ::syscall(SYS_getrandom, buf, size, flags);
+#endif
+    }
+};
+
+} // detail
+} // uuids
+} // boost

--- a/include/boost/uuid/detail/random_provider_include_platform.hpp
+++ b/include/boost/uuid/detail/random_provider_include_platform.hpp
@@ -17,6 +17,8 @@
 # include <boost/uuid/detail/random_provider_bcrypt.ipp>
 #elif defined(BOOST_UUID_RANDOM_PROVIDER_GETENTROPY)
 # include <boost/uuid/detail/random_provider_getentropy.ipp>
+#elif defined(BOOST_UUID_RANDOM_PROVIDER_GETRANDOM)
+# include <boost/uuid/detail/random_provider_getrandom.ipp>
 #elif defined(BOOST_UUID_RANDOM_PROVIDER_POSIX)
 # include <boost/uuid/detail/random_provider_posix.ipp>
 #elif defined(BOOST_UUID_RANDOM_PROVIDER_WINCRYPT)

--- a/test/Jamfile.v2
+++ b/test/Jamfile.v2
@@ -169,22 +169,39 @@ test-suite uuid :
         <target-os>windows:<build>yes                                   # except for windows
       : test_detail_random_provider_sad_wincrypt ]
 
-    # CI builds in travis will eventually select getentropy when they move
+    # CI builds in travis will eventually select getrandom/getentropy when they move
     # to a version of ubuntu with glibc-2.25 on it, so when that happens keep 
     # testing the posix provider:
-    [ run test_detail_random_provider.cpp 
+    [ run test_detail_random_provider.cpp
       : : :
-        <define>BOOST_UUID_RANDOM_PROVIDER_FORCE_POSIX                  # will force POSIX over getentropy
+        <define>BOOST_UUID_RANDOM_PROVIDER_FORCE_POSIX                  # will force POSIX over getrandom/getentropy
         <target-os>windows:<build>no                                    # do not bother running on windows
         <toolset>clang-cloudabi:<build>no                               # no need to build under cloudabi
       : test_detail_random_provider_happy_posix ]
 
-    [ run test_detail_random_provider.cpp 
+    [ run test_detail_random_provider.cpp
       : : :
-        <define>BOOST_UUID_RANDOM_PROVIDER_FORCE_POSIX                  # will force POSIX over getentropy
+        <define>BOOST_UUID_RANDOM_PROVIDER_FORCE_POSIX                  # will force POSIX over getrandom/getentropy
         <define>BOOST_UUID_TEST_RANDOM_MOCK                             # redirect code to use mock system calls
         <target-os>windows:<build>no                                    # do not bother running on windows
         <toolset>clang-cloudabi:<build>no                               # no need to build under cloudabi
       : test_detail_random_provider_sad_posix ]
+
+    # Force running tests for getentropy despite it's not going to be used on Linux. getentropy
+    # may be used on systems other than Linux, which are not part of the CI testers pool.
+    [ run test_detail_random_provider.cpp
+      : : :
+        <define>BOOST_UUID_RANDOM_PROVIDER_DISABLE_GETRANDOM            # will force getentropy over getrandom
+        <build>no
+        <target-os>linux:<build>yes                                     # build only on linux (or any other systems that support getentropy)
+      : test_detail_random_provider_happy_getentropy ]
+
+    [ run test_detail_random_provider.cpp
+      : : :
+        <define>BOOST_UUID_RANDOM_PROVIDER_DISABLE_GETRANDOM            # will force getentropy over getrandom
+        <define>BOOST_UUID_TEST_RANDOM_MOCK                             # redirect code to use mock system calls
+        <build>no
+        <target-os>linux:<build>yes                                     # build only on linux (or any other systems that support getentropy)
+      : test_detail_random_provider_sad_getentropy ]
 
     ;


### PR DESCRIPTION
getrandom is the base implementation for getentropy on Linux. It is also
available in the form of a syscall, which can be called directly on systems with
glibc versions older than 2.25 which don't yet provide wrappers for getrandom or
getentropy but have a recent enough Linux kernel (for example, Debian Stretch).

On systems other than Linux (e.g. Solaris) getentropy is documented as a
source for initialization of a user-space PRNG instead of a direct source
for random data. Since we use the random data directly to initialize UUIDs,
using getrandom on other platforms, where available, would be more preferable
than getentropy. Unfortunately, the only other platform that is known to support
both getentropy and getrandom (Solaris) documents getrandom to return 0
on error, which is a valid return value on Linux. It's not clear if this is
a documentation error or a true incompatibility, and I have no way to test,
so do not use getrandom on Solaris for now. For this reason (and in case
if it is also used on some other platforms) getentropy backend is still
preserved.