### PR TITLE
Make entropy_error default visible

### DIFF
--- a/include/boost/uuid/entropy_error.hpp
+++ b/include/boost/uuid/entropy_error.hpp
@@ -1,5 +1,5 @@
 //
-// Copyright (c) 2017 James E. King III
+// Copyright (c) 2017, 2018 James E. King III
 //
 // Distributed under the Boost Software License, Version 1.0.
 // (See accompanying file LICENSE_1_0.txt or copy at
@@ -11,6 +11,7 @@
 #ifndef BOOST_UUID_RANDOM_ENTROPY_ERROR_HPP
 #define BOOST_UUID_RANDOM_ENTROPY_ERROR_HPP
 
+#include <boost/config.hpp>
 #include <boost/cstdint.hpp>
 #include <stdexcept>
 #include <string>
@@ -21,7 +22,7 @@ namespace uuids {
 //! \brief Given boost::system::system_error is in a module that
 //!        is not header-only, we define our own exception type
 //!        to handle entropy provider errors instead,
-class entropy_error : public std::runtime_error
+class BOOST_SYMBOL_VISIBLE entropy_error : public std::runtime_error
 {
 public:
     entropy_error(boost::intmax_t errCode, const std::string& message)


### PR DESCRIPTION
See https://github.com/boostorg/function/pull/24 as to why.