### PR TITLE
Fix clang warnings

### DIFF
--- a/include/boost/uuid/basic_name_generator.hpp
+++ b/include/boost/uuid/basic_name_generator.hpp
@@ -73,7 +73,7 @@ class basic_name_generator
         hash.process_bytes(namespace_uuid.begin(), namespace_uuid.size());
         hash.process_bytes(buffer, byte_count);
         return hash_to_uuid(hash);
-    };
+    }
 
 private:
     // we convert all characters to uint32_t so that each

--- a/include/boost/uuid/string_generator.hpp
+++ b/include/boost/uuid/string_generator.hpp
@@ -15,6 +15,7 @@
 #include <algorithm> // for find
 #include <stdexcept>
 #include <boost/throw_exception.hpp>
+#include <boost/config.hpp>
 
 #ifdef BOOST_NO_STDC_NAMESPACE
 namespace std {
@@ -187,7 +188,7 @@ private:
         }
     }
     
-    void throw_invalid() const {
+    BOOST_NORETURN void throw_invalid() const {
         BOOST_THROW_EXCEPTION(std::runtime_error("invalid uuid string"));
     }
 };


### PR DESCRIPTION
This fixes -Wextra-semi and -Wmissing-noreturn. See individual commits for details.