### PR TITLE
Fixes https://github.com/boostorg/uuid/issues/94

### DIFF
--- a/include/boost/uuid/detail/random_provider_bcrypt.ipp
+++ b/include/boost/uuid/detail/random_provider_bcrypt.ipp
@@ -19,9 +19,13 @@
 
 #if defined(BOOST_UUID_FORCE_AUTO_LINK) || (!defined(BOOST_ALL_NO_LIB) && !defined(BOOST_UUID_RANDOM_PROVIDER_NO_LIB))
 #   define BOOST_LIB_NAME "bcrypt"
-#   define BOOST_AUTO_LINK_NOMANGLE
-#   include <boost/config/auto_link.hpp>
-#   undef BOOST_AUTO_LINK_NOMANGLE
+#   if defined(BOOST_AUTO_LINK_NOMANGLE)
+#      include <boost/config/auto_link.hpp>
+#   else
+#      define BOOST_AUTO_LINK_NOMANGLE
+#      include <boost/config/auto_link.hpp>
+#      undef BOOST_AUTO_LINK_NOMANGLE
+#   endif
 #endif
 
 namespace boost {

--- a/include/boost/uuid/detail/random_provider_wincrypt.ipp
+++ b/include/boost/uuid/detail/random_provider_wincrypt.ipp
@@ -27,9 +27,13 @@
 #   else
 #      define BOOST_LIB_NAME "advapi32"
 #   endif
-#   define BOOST_AUTO_LINK_NOMANGLE
-#   include <boost/config/auto_link.hpp>
-#   undef BOOST_AUTO_LINK_NOMANGLE
+#   if defined(BOOST_AUTO_LINK_NOMANGLE)
+#      include <boost/config/auto_link.hpp>
+#   else
+#      define BOOST_AUTO_LINK_NOMANGLE
+#      include <boost/config/auto_link.hpp>
+#      undef BOOST_AUTO_LINK_NOMANGLE
+#   endif
 #endif
 
 namespace boost {


### PR DESCRIPTION
Avoid undefining BOOST_AUTO_LINK_NOMANGLE if it was previously defined.

Maybe better solution would be to directly
#pragma comment(lib, "bcrypt.lib")
#pragma comment(lib, "advapi32.lib")
or
#pragma comment(lib, "coredll.lib")

Since <boost/config/auto_link.hpp> seems to be oriented for various logics for linking boost libs and those 3 are not boost libs.

Didn't want to go to change that big myself, so implemented one that still uses auto_link.hpp but solves the problem.

This fixes #94 