### PR TITLE
Disable getentropy backend on Linux and Android

### DIFF
--- a/include/boost/uuid/detail/random_provider_detect_platform.hpp
+++ b/include/boost/uuid/detail/random_provider_detect_platform.hpp
@@ -25,6 +25,12 @@
 #endif // defined(SYS_getrandom)
 #endif
 
+// On Linux, getentropy is implemented via getrandom. If we know that getrandom is not supported by the kernel, getentropy
+// will certainly not work, even if libc provides a wrapper function for it. There is no reason, ever, to use getentropy on that platform.
+#if !defined(BOOST_UUID_RANDOM_PROVIDER_DISABLE_GETENTROPY) && (defined(__linux__) || defined(__linux) || defined(linux) || defined(__ANDROID__))
+#define BOOST_UUID_RANDOM_PROVIDER_DISABLE_GETENTROPY
+#endif
+
 //
 // Platform Detection - will load in the correct header and
 // will define the class <tt>random_provider_base</tt>.
@@ -54,7 +60,7 @@
 # define BOOST_UUID_RANDOM_PROVIDER_GETRANDOM
 # define BOOST_UUID_RANDOM_PROVIDER_NAME getrandom
 
-#elif BOOST_LIB_C_GNU >= BOOST_VERSION_NUMBER(2, 25, 0) && !defined(BOOST_UUID_RANDOM_PROVIDER_FORCE_POSIX)
+#elif BOOST_LIB_C_GNU >= BOOST_VERSION_NUMBER(2, 25, 0) && !defined(BOOST_UUID_RANDOM_PROVIDER_FORCE_POSIX) && !defined(BOOST_UUID_RANDOM_PROVIDER_DISABLE_GETENTROPY)
 # define BOOST_UUID_RANDOM_PROVIDER_GETENTROPY
 # define BOOST_UUID_RANDOM_PROVIDER_NAME getentropy
 


### PR DESCRIPTION
Since getentropy is implemented via getrandom in Linux kernel, getentropy
cannot work if the kernel doesn't support getrandom. Given this, there is
no reason to ever use getentropy on Linux.

We used to allow this backend based on glibc version check, but there are
configurations where a newer glibc is running with an older kernel, and
getentropy always fails in runtime. Disabling getentropy in such cases
allows to fall back to the generic POSIX backend.

References https://github.com/boostorg/uuid/issues/92#issuecomment-479380506.

This fixes #92 