### PR TITLE
Reuse hash_value impl. for std::hash support

### DIFF
--- a/include/boost/uuid/uuid_hash.hpp
+++ b/include/boost/uuid/uuid_hash.hpp
@@ -12,8 +12,6 @@
 #define BOOST_UUID_HASH_HPP
 
 #include <boost/config.hpp>
-#include <boost/container_hash/hash.hpp>
-#include <boost/uuid/uuid_io.hpp>
 
 #ifdef BOOST_HAS_PRAGMA_ONCE
 #pragma once
@@ -31,7 +29,13 @@ namespace std
     {
         std::size_t operator () (const boost::uuids::uuid& value) const BOOST_NOEXCEPT
         {
-            return boost::hash_value(to_string(value));
+            std::size_t seed = 0;
+            for(uuid::const_iterator i=u.begin(), e=u.end(); i != e; ++i)
+            {
+                seed ^= static_cast<std::size_t>(*i) + 0x9e3779b9 + (seed << 6) + (seed >> 2);
+            }
+
+            return seed;
         }
     };
 }

--- a/include/boost/uuid/uuid_hash.hpp
+++ b/include/boost/uuid/uuid_hash.hpp
@@ -30,7 +30,7 @@ namespace std
         std::size_t operator () (const boost::uuids::uuid& value) const BOOST_NOEXCEPT
         {
             std::size_t seed = 0;
-            for(uuid::const_iterator i=u.begin(), e=u.end(); i != e; ++i)
+            for(uuid::const_iterator i=value.begin(), e=value.end(); i != e; ++i)
             {
                 seed ^= static_cast<std::size_t>(*i) + 0x9e3779b9 + (seed << 6) + (seed >> 2);
             }

--- a/include/boost/uuid/uuid_hash.hpp
+++ b/include/boost/uuid/uuid_hash.hpp
@@ -30,7 +30,7 @@ namespace std
         std::size_t operator () (const boost::uuids::uuid& value) const BOOST_NOEXCEPT
         {
             std::size_t seed = 0;
-            for(uuid::const_iterator i=value.begin(), e=value.end(); i != e; ++i)
+            for(boost::uuids::uuid::const_iterator i=value.begin(), e=value.end(); i != e; ++i)
             {
                 seed ^= static_cast<std::size_t>(*i) + 0x9e3779b9 + (seed << 6) + (seed >> 2);
             }


### PR DESCRIPTION
A temporary string allocation shouldn't be necessary for hashing