### PR TITLE
Implement std::hash in terms of hash_value.

### DIFF
--- a/include/boost/uuid/uuid_hash.hpp
+++ b/include/boost/uuid/uuid_hash.hpp
@@ -13,7 +13,7 @@
 
 #include <boost/config.hpp>
 #include <boost/container_hash/hash.hpp>
-#include <boost/uuid/uuid_io.hpp>
+#include <boost/uuid/uuid.hpp>
 
 #ifdef BOOST_HAS_PRAGMA_ONCE
 #pragma once
@@ -31,7 +31,7 @@ namespace std
     {
         std::size_t operator () (const boost::uuids::uuid& value) const BOOST_NOEXCEPT
         {
-            return boost::hash_value(to_string(value));
+            return boost::uuids::hash_value(value);
         }
     };
 }


### PR DESCRIPTION
Not only it makes the two implementations equivalent, it also fixes the bug
of to_string throwing an exception in the noexcept function. It is also
more efficient as there is no need for the temporary string construction.

Alternative to https://github.com/boostorg/uuid/pull/99.
