### PR TITLE
Fix for typo (LICENCE) and suggestion for https links

### DIFF
--- a/Jamfile
+++ b/Jamfile
@@ -4,7 +4,7 @@
 #
 #  Use, modification, and distribution are subject to the
 #  Boost Software License, Version 1.0. (See accompanying file
-#  LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+#  LICENSE_1_0.txt or copy at https://www.boost.org/LICENSE_1_0.txt)
 
 project libs/uuid
     : requirements

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@ Uuid, part of collection of the [Boost C++ Libraries](http://github.com/boostorg
 
 ### License
 
-Distributed under the [Boost Software License, Version 1.0](http://www.boost.org/LICENSE_1_0.txt).
+Distributed under the [Boost Software License, Version 1.0](https://www.boost.org/LICENSE_1_0.txt).
 
 ### Properties
 
@@ -28,14 +28,14 @@ Branch          | Travis | Appveyor | Coverity Scan | codecov.io | Deps | Docs |
 
 * [Ask questions](http://stackoverflow.com/questions/ask?tags=c%2B%2B,boost,boost-uuid)
 * [Report bugs](https://github.com/boostorg/uuid/issues): Be sure to mention Boost version, platform and compiler you're using. A small compilable code sample to reproduce the problem is always good as well.
-* Submit your patches as pull requests against **develop** branch. Note that by submitting patches you agree to license your modifications under the [Boost Software License, Version 1.0](http://www.boost.org/LICENSE_1_0.txt).
+* Submit your patches as pull requests against **develop** branch. Note that by submitting patches you agree to license your modifications under the [Boost Software License, Version 1.0](https://www.boost.org/LICENSE_1_0.txt).
 * Discussions about the library are held on the [Boost developers mailing list](http://www.boost.org/community/groups.html#main). Be sure to read the [discussion policy](http://www.boost.org/community/policy.html) before posting and add the `[uuid]` tag at the beginning of the subject line.
 
 ### Code Example - UUID Generation
 
     // Copyright 2017 James E. King III
     // Distributed under the Boost Software License, Version 1.0.
-    // (See http://www.boost.org/LICENSE_1_0.txt)
+    // (See https://www.boost.org/LICENSE_1_0.txt)
     //  mkuuid.cpp example
     
     #include <boost/lexical_cast.hpp>

--- a/doc/index.html
+++ b/doc/index.html
@@ -37,7 +37,7 @@
 <hr>
 <p>© Copyright Andy Tompkins, 2006</p>
 <p> Distributed under the Boost Software 
-License, Version 1.0. (See accompanying file <a href="../../../LICENSE_1_0.txt">LICENSE_1_0.txt</a> or copy at <a href="http://www.boost.org/LICENSE_1_0.txt">
+License, Version 1.0. (See accompanying file <a href="../../../LICENSE_1_0.txt">LICENSE_1_0.txt</a> or copy at <a href="https://www.boost.org/LICENSE_1_0.txt">
 www.boost.org/LICENSE_1_0.txt</a>)</p>
 </body>
 </html>

--- a/doc/uuid.html
+++ b/doc/uuid.html
@@ -848,7 +848,7 @@ mailing list provided useful comments and greatly helped to shape the library.
 <p>© Copyright Andy Tompkins, 2006</p>
 <p>© Copyright 2017 James E. King III</p>
 <p> Distributed under the Boost Software
-License, Version 1.0. (See accompanying file <a href="../../../LICENSE_1_0.txt">LICENSE_1_0.txt</a> or copy at <a href="http://www.boost.org/LICENSE_1_0.txt">
+License, Version 1.0. (See accompanying file <a href="../../../LICENSE_1_0.txt">LICENSE_1_0.txt</a> or copy at <a href="https://www.boost.org/LICENSE_1_0.txt">
 www.boost.org/LICENSE_1_0.txt</a>)</p>
 </body>
 </html>

--- a/include/boost/uuid/basic_name_generator.hpp
+++ b/include/boost/uuid/basic_name_generator.hpp
@@ -5,7 +5,7 @@
 
 // Distributed under the Boost Software License, Version 1.0. (See
 // accompanying file LICENSE_1_0.txt or copy at
-//  http://www.boost.org/LICENSE_1_0.txt)
+//  https://www.boost.org/LICENSE_1_0.txt)
 
 #ifndef BOOST_UUID_BASIC_NAME_GENERATOR_HPP
 #define BOOST_UUID_BASIC_NAME_GENERATOR_HPP

--- a/include/boost/uuid/detail/config.hpp
+++ b/include/boost/uuid/detail/config.hpp
@@ -2,7 +2,7 @@
  *            Copyright Andrey Semashev 2013.
  * Distributed under the Boost Software License, Version 1.0.
  *    (See accompanying file LICENSE_1_0.txt or copy at
- *          http://www.boost.org/LICENSE_1_0.txt)
+ *          https://www.boost.org/LICENSE_1_0.txt)
  */
 /*!
  * \file   uuid/detail/config.hpp

--- a/include/boost/uuid/detail/md5.hpp
+++ b/include/boost/uuid/detail/md5.hpp
@@ -21,7 +21,7 @@
 
 // Distributed under the Boost Software License, Version 1.0. (See
 // accompanying file LICENSE_1_0.txt or copy at
-// http://www.boost.org/LICENSE_1_0.txt)
+// https://www.boost.org/LICENSE_1_0.txt)
 
 #ifndef BOOST_UUID_MD5_HPP
 #define BOOST_UUID_MD5_HPP

--- a/include/boost/uuid/detail/random_provider.hpp
+++ b/include/boost/uuid/detail/random_provider.hpp
@@ -3,7 +3,7 @@
 //
 // Distributed under the Boost Software License, Version 1.0.
 // (See accompanying file LICENSE_1_0.txt or copy at
-//   http://www.boost.org/LICENCE_1_0.txt)
+//   http://www.boost.org/LICENSE_1_0.txt)
 //
 // Platform-specific random entropy provider
 //

--- a/include/boost/uuid/detail/random_provider.hpp
+++ b/include/boost/uuid/detail/random_provider.hpp
@@ -3,7 +3,7 @@
 //
 // Distributed under the Boost Software License, Version 1.0.
 // (See accompanying file LICENSE_1_0.txt or copy at
-//   http://www.boost.org/LICENSE_1_0.txt)
+//   https://www.boost.org/LICENSE_1_0.txt)
 //
 // Platform-specific random entropy provider
 //

--- a/include/boost/uuid/detail/random_provider_arc4random.ipp
+++ b/include/boost/uuid/detail/random_provider_arc4random.ipp
@@ -3,7 +3,7 @@
 //
 // Distributed under the Boost Software License, Version 1.0.
 // (See accompanying file LICENSE_1_0.txt or copy at
-//   http://www.boost.org/LICENSE_1_0.txt)
+//   https://www.boost.org/LICENSE_1_0.txt)
 //
 // "A Replacement Call for Random"
 // https://man.openbsd.org/arc4random.3

--- a/include/boost/uuid/detail/random_provider_arc4random.ipp
+++ b/include/boost/uuid/detail/random_provider_arc4random.ipp
@@ -3,7 +3,7 @@
 //
 // Distributed under the Boost Software License, Version 1.0.
 // (See accompanying file LICENSE_1_0.txt or copy at
-//   http://www.boost.org/LICENCE_1_0.txt)
+//   http://www.boost.org/LICENSE_1_0.txt)
 //
 // "A Replacement Call for Random"
 // https://man.openbsd.org/arc4random.3

--- a/include/boost/uuid/detail/random_provider_bcrypt.ipp
+++ b/include/boost/uuid/detail/random_provider_bcrypt.ipp
@@ -3,7 +3,7 @@
 //
 // Distributed under the Boost Software License, Version 1.0.
 // (See accompanying file LICENSE_1_0.txt or copy at
-//   http://www.boost.org/LICENSE_1_0.txt)
+//   https://www.boost.org/LICENSE_1_0.txt)
 //
 // BCrypt provider for entropy
 //

--- a/include/boost/uuid/detail/random_provider_bcrypt.ipp
+++ b/include/boost/uuid/detail/random_provider_bcrypt.ipp
@@ -3,7 +3,7 @@
 //
 // Distributed under the Boost Software License, Version 1.0.
 // (See accompanying file LICENSE_1_0.txt or copy at
-//   http://www.boost.org/LICENCE_1_0.txt)
+//   http://www.boost.org/LICENSE_1_0.txt)
 //
 // BCrypt provider for entropy
 //

--- a/include/boost/uuid/detail/random_provider_detect_platform.hpp
+++ b/include/boost/uuid/detail/random_provider_detect_platform.hpp
@@ -3,7 +3,7 @@
 //
 // Distributed under the Boost Software License, Version 1.0.
 // (See accompanying file LICENSE_1_0.txt or copy at
-//   http://www.boost.org/LICENCE_1_0.txt)
+//   http://www.boost.org/LICENSE_1_0.txt)
 //
 // Platform-specific random entropy provider platform detection
 //

--- a/include/boost/uuid/detail/random_provider_detect_platform.hpp
+++ b/include/boost/uuid/detail/random_provider_detect_platform.hpp
@@ -3,7 +3,7 @@
 //
 // Distributed under the Boost Software License, Version 1.0.
 // (See accompanying file LICENSE_1_0.txt or copy at
-//   http://www.boost.org/LICENSE_1_0.txt)
+//   https://www.boost.org/LICENSE_1_0.txt)
 //
 // Platform-specific random entropy provider platform detection
 //

--- a/include/boost/uuid/detail/random_provider_getentropy.ipp
+++ b/include/boost/uuid/detail/random_provider_getentropy.ipp
@@ -3,7 +3,7 @@
 //
 // Distributed under the Boost Software License, Version 1.0.
 // (See accompanying file LICENSE_1_0.txt or copy at
-//   http://www.boost.org/LICENSE_1_0.txt)
+//   https://www.boost.org/LICENSE_1_0.txt)
 //
 // getentropy() capable platforms
 //

--- a/include/boost/uuid/detail/random_provider_getentropy.ipp
+++ b/include/boost/uuid/detail/random_provider_getentropy.ipp
@@ -3,7 +3,7 @@
 //
 // Distributed under the Boost Software License, Version 1.0.
 // (See accompanying file LICENSE_1_0.txt or copy at
-//   http://www.boost.org/LICENCE_1_0.txt)
+//   http://www.boost.org/LICENSE_1_0.txt)
 //
 // getentropy() capable platforms
 //

--- a/include/boost/uuid/detail/random_provider_getrandom.ipp
+++ b/include/boost/uuid/detail/random_provider_getrandom.ipp
@@ -3,7 +3,7 @@
 //
 // Distributed under the Boost Software License, Version 1.0.
 // (See accompanying file LICENSE_1_0.txt or copy at
-//   http://www.boost.org/LICENSE_1_0.txt)
+//   https://www.boost.org/LICENSE_1_0.txt)
 //
 // getrandom() capable platforms
 //

--- a/include/boost/uuid/detail/random_provider_getrandom.ipp
+++ b/include/boost/uuid/detail/random_provider_getrandom.ipp
@@ -3,7 +3,7 @@
 //
 // Distributed under the Boost Software License, Version 1.0.
 // (See accompanying file LICENSE_1_0.txt or copy at
-//   http://www.boost.org/LICENCE_1_0.txt)
+//   http://www.boost.org/LICENSE_1_0.txt)
 //
 // getrandom() capable platforms
 //

--- a/include/boost/uuid/detail/random_provider_include_platform.hpp
+++ b/include/boost/uuid/detail/random_provider_include_platform.hpp
@@ -3,7 +3,7 @@
 //
 // Distributed under the Boost Software License, Version 1.0.
 // (See accompanying file LICENSE_1_0.txt or copy at
-//   http://www.boost.org/LICENSE_1_0.txt)
+//   https://www.boost.org/LICENSE_1_0.txt)
 //
 // Platform-specific random entropy provider platform definition
 //

--- a/include/boost/uuid/detail/random_provider_include_platform.hpp
+++ b/include/boost/uuid/detail/random_provider_include_platform.hpp
@@ -3,7 +3,7 @@
 //
 // Distributed under the Boost Software License, Version 1.0.
 // (See accompanying file LICENSE_1_0.txt or copy at
-//   http://www.boost.org/LICENCE_1_0.txt)
+//   http://www.boost.org/LICENSE_1_0.txt)
 //
 // Platform-specific random entropy provider platform definition
 //

--- a/include/boost/uuid/detail/random_provider_posix.ipp
+++ b/include/boost/uuid/detail/random_provider_posix.ipp
@@ -7,7 +7,7 @@
 *
 * Distributed under the Boost Software License, Version 1.0. (See
 * accompanying file LICENSE_1_0.txt or copy at
-* http://www.boost.org/LICENSE_1_0.txt)
+* https://www.boost.org/LICENSE_1_0.txt)
 *
 * $Id$
 */

--- a/include/boost/uuid/detail/random_provider_wincrypt.ipp
+++ b/include/boost/uuid/detail/random_provider_wincrypt.ipp
@@ -7,7 +7,7 @@
 *
 * Distributed under the Boost Software License, Version 1.0. (See
 * accompanying file LICENSE_1_0.txt or copy at
-* http://www.boost.org/LICENSE_1_0.txt)
+* https://www.boost.org/LICENSE_1_0.txt)
 *
 * $Id$
 */

--- a/include/boost/uuid/detail/sha1.hpp
+++ b/include/boost/uuid/detail/sha1.hpp
@@ -1,7 +1,7 @@
 // Copyright 2007 Andy Tompkins.
 // Distributed under the Boost Software License, Version 1.0. (See
 // accompanying file LICENSE_1_0.txt or copy at
-// http://www.boost.org/LICENSE_1_0.txt)
+// https://www.boost.org/LICENSE_1_0.txt)
 
 // Revision History
 //  29 May 2007 - Initial Revision

--- a/include/boost/uuid/detail/uuid_generic.ipp
+++ b/include/boost/uuid/detail/uuid_generic.ipp
@@ -2,7 +2,7 @@
  *             Copyright Andy Tompkins 2006.
  * Distributed under the Boost Software License, Version 1.0.
  *    (See accompanying file LICENSE_1_0.txt or copy at
- *          http://www.boost.org/LICENSE_1_0.txt)
+ *          https://www.boost.org/LICENSE_1_0.txt)
  */
 /*!
  * \file   uuid/detail/uuid_generic.ipp

--- a/include/boost/uuid/detail/uuid_x86.ipp
+++ b/include/boost/uuid/detail/uuid_x86.ipp
@@ -2,7 +2,7 @@
  *            Copyright Andrey Semashev 2013.
  * Distributed under the Boost Software License, Version 1.0.
  *    (See accompanying file LICENSE_1_0.txt or copy at
- *          http://www.boost.org/LICENSE_1_0.txt)
+ *          https://www.boost.org/LICENSE_1_0.txt)
  */
 /*!
  * \file   uuid/detail/uuid_x86.ipp

--- a/include/boost/uuid/entropy_error.hpp
+++ b/include/boost/uuid/entropy_error.hpp
@@ -3,7 +3,7 @@
 //
 // Distributed under the Boost Software License, Version 1.0.
 // (See accompanying file LICENSE_1_0.txt or copy at
-//   http://www.boost.org/LICENSE_1_0.txt)
+//   https://www.boost.org/LICENSE_1_0.txt)
 //
 // Entropy error class
 //

--- a/include/boost/uuid/entropy_error.hpp
+++ b/include/boost/uuid/entropy_error.hpp
@@ -3,7 +3,7 @@
 //
 // Distributed under the Boost Software License, Version 1.0.
 // (See accompanying file LICENSE_1_0.txt or copy at
-//   http://www.boost.org/LICENCE_1_0.txt)
+//   http://www.boost.org/LICENSE_1_0.txt)
 //
 // Entropy error class
 //

--- a/include/boost/uuid/name_generator.hpp
+++ b/include/boost/uuid/name_generator.hpp
@@ -5,7 +5,7 @@
 
 // Distributed under the Boost Software License, Version 1.0. (See
 // accompanying file LICENSE_1_0.txt or copy at
-//  http://www.boost.org/LICENSE_1_0.txt)
+//  https://www.boost.org/LICENSE_1_0.txt)
 
 #ifndef BOOST_UUID_NAME_GENERATOR_HPP
 #define BOOST_UUID_NAME_GENERATOR_HPP

--- a/include/boost/uuid/name_generator_md5.hpp
+++ b/include/boost/uuid/name_generator_md5.hpp
@@ -4,7 +4,7 @@
 
 // Distributed under the Boost Software License, Version 1.0. (See
 // accompanying file LICENSE_1_0.txt or copy at
-//  http://www.boost.org/LICENSE_1_0.txt)
+//  https://www.boost.org/LICENSE_1_0.txt)
 
 #ifndef BOOST_UUID_NAME_GENERATOR_MD5_HPP
 #define BOOST_UUID_NAME_GENERATOR_MD5_HPP

--- a/include/boost/uuid/name_generator_sha1.hpp
+++ b/include/boost/uuid/name_generator_sha1.hpp
@@ -5,7 +5,7 @@
 
 // Distributed under the Boost Software License, Version 1.0. (See
 // accompanying file LICENSE_1_0.txt or copy at
-//  http://www.boost.org/LICENSE_1_0.txt)
+//  https://www.boost.org/LICENSE_1_0.txt)
 
 #ifndef BOOST_UUID_NAME_GENERATOR_SHA1_HPP
 #define BOOST_UUID_NAME_GENERATOR_SHA1_HPP

--- a/include/boost/uuid/nil_generator.hpp
+++ b/include/boost/uuid/nil_generator.hpp
@@ -3,7 +3,7 @@
 // Copyright 2010 Andy Tompkins.
 // Distributed under the Boost Software License, Version 1.0. (See
 // accompanying file LICENSE_1_0.txt or copy at
-// http://www.boost.org/LICENSE_1_0.txt)
+// https://www.boost.org/LICENSE_1_0.txt)
 
 #ifndef BOOST_UUID_NIL_GENERATOR_HPP
 #define BOOST_UUID_NIL_GENERATOR_HPP

--- a/include/boost/uuid/random_generator.hpp
+++ b/include/boost/uuid/random_generator.hpp
@@ -4,7 +4,7 @@
 // Copyright 2017 James E. King III
 // Distributed under the Boost Software License, Version 1.0. (See
 // accompanying file LICENSE_1_0.txt or copy at
-// http://www.boost.org/LICENSE_1_0.txt)
+// https://www.boost.org/LICENSE_1_0.txt)
 
 #ifndef BOOST_UUID_RANDOM_GENERATOR_HPP
 #define BOOST_UUID_RANDOM_GENERATOR_HPP

--- a/include/boost/uuid/string_generator.hpp
+++ b/include/boost/uuid/string_generator.hpp
@@ -3,7 +3,7 @@
 // Copyright 2010 Andy Tompkins.
 // Distributed under the Boost Software License, Version 1.0. (See
 // accompanying file LICENSE_1_0.txt or copy at
-// http://www.boost.org/LICENSE_1_0.txt)
+// https://www.boost.org/LICENSE_1_0.txt)
 
 #ifndef BOOST_UUID_STRING_GENERATOR_HPP
 #define BOOST_UUID_STRING_GENERATOR_HPP

--- a/include/boost/uuid/uuid.hpp
+++ b/include/boost/uuid/uuid.hpp
@@ -3,7 +3,7 @@
 // Copyright 2006 Andy Tompkins.
 // Distributed under the Boost Software License, Version 1.0. (See
 // accompanying file LICENSE_1_0.txt or copy at
-// http://www.boost.org/LICENSE_1_0.txt)
+// https://www.boost.org/LICENSE_1_0.txt)
 
 // Revision History
 //  06 Feb 2006 - Initial Revision

--- a/include/boost/uuid/uuid_generators.hpp
+++ b/include/boost/uuid/uuid_generators.hpp
@@ -3,7 +3,7 @@
 // Copyright 2006 Andy Tompkins.
 // Distributed under the Boost Software License, Version 1.0. (See
 // accompanying file LICENSE_1_0.txt or copy at
-// http://www.boost.org/LICENSE_1_0.txt)
+// https://www.boost.org/LICENSE_1_0.txt)
 
 // Revision History
 //  06 Feb 2006 - Initial Revision

--- a/include/boost/uuid/uuid_hash.hpp
+++ b/include/boost/uuid/uuid_hash.hpp
@@ -3,7 +3,7 @@
 //
 // Distributed under the Boost Software License, Version 1.0.
 // (See accompanying file LICENSE_1_0.txt or copy at
-//   http://www.boost.org/LICENCE_1_0.txt)
+//   http://www.boost.org/LICENSE_1_0.txt)
 //
 // std::hash support for uuid
 //

--- a/include/boost/uuid/uuid_hash.hpp
+++ b/include/boost/uuid/uuid_hash.hpp
@@ -3,7 +3,7 @@
 //
 // Distributed under the Boost Software License, Version 1.0.
 // (See accompanying file LICENSE_1_0.txt or copy at
-//   http://www.boost.org/LICENSE_1_0.txt)
+//   https://www.boost.org/LICENSE_1_0.txt)
 //
 // std::hash support for uuid
 //

--- a/include/boost/uuid/uuid_io.hpp
+++ b/include/boost/uuid/uuid_io.hpp
@@ -3,7 +3,7 @@
 // Copyright 2009 Andy Tompkins.
 // Distributed under the Boost Software License, Version 1.0. (See
 // accompanying file LICENSE_1_0.txt or copy at
-// http://www.boost.org/LICENSE_1_0.txt)
+// https://www.boost.org/LICENSE_1_0.txt)
 
 // Revision History
 //  20 Mar 2009 - Initial Revision

--- a/include/boost/uuid/uuid_serialize.hpp
+++ b/include/boost/uuid/uuid_serialize.hpp
@@ -3,7 +3,7 @@
 // Copyright 2007 Andy Tompkins.
 // Distributed under the Boost Software License, Version 1.0. (See
 // accompanying file LICENSE_1_0.txt or copy at
-// http://www.boost.org/LICENSE_1_0.txt)
+// https://www.boost.org/LICENSE_1_0.txt)
 
 // Revision History
 //  12 Nov 2007 - Initial Revision

--- a/index.html
+++ b/index.html
@@ -1,6 +1,6 @@
 <!-- Copyright (c) 2002-2003 William E. Kempf.
      Subject to the Boost Software License, Version 1.0. 
-     (See accompanying file LICENSE_1_0.txt or  http://www.boost.org/LICENSE_1_0.txt)
+     (See accompanying file LICENSE_1_0.txt or  https://www.boost.org/LICENSE_1_0.txt)
 -->
 
 <html>

--- a/test/Jamfile.v2
+++ b/test/Jamfile.v2
@@ -2,7 +2,7 @@
 # Copyright 2017 - 2018 James E. King III
 # Distributed under the Boost Software License, Version 1.0. (See
 # accompanying file LICENSE_1_0.txt or copy at
-# http://www.boost.org/LICENSE_1_0.txt)
+# https://www.boost.org/LICENSE_1_0.txt)
 
 lib bcrypt ;
 

--- a/test/compile-fail/basic_random_generator_no_copy_assign.cpp
+++ b/test/compile-fail/basic_random_generator_no_copy_assign.cpp
@@ -2,7 +2,7 @@
 
 // Distributed under the Boost Software License, Version 1.0. (See
 // accompanying file LICENSE_1_0.txt or copy at
-// http://www.boost.org/LICENSE_1_0.txt)
+// https://www.boost.org/LICENSE_1_0.txt)
 
 // The test verifies that basic_random_generator is not copy assignable
 

--- a/test/compile-fail/basic_random_generator_no_copy_ctor.cpp
+++ b/test/compile-fail/basic_random_generator_no_copy_ctor.cpp
@@ -2,7 +2,7 @@
 
 // Distributed under the Boost Software License, Version 1.0. (See
 // accompanying file LICENSE_1_0.txt or copy at
-// http://www.boost.org/LICENSE_1_0.txt)
+// https://www.boost.org/LICENSE_1_0.txt)
 
 // The test verifies that basic_random_generator is not copy constructible
 

--- a/test/compile-fail/random_generator_no_copy_assign.cpp
+++ b/test/compile-fail/random_generator_no_copy_assign.cpp
@@ -2,7 +2,7 @@
 
 // Distributed under the Boost Software License, Version 1.0. (See
 // accompanying file LICENSE_1_0.txt or copy at
-// http://www.boost.org/LICENSE_1_0.txt)
+// https://www.boost.org/LICENSE_1_0.txt)
 
 // The test verifies that random_generator is not copy assignable
 

--- a/test/compile-fail/random_generator_no_copy_ctor.cpp
+++ b/test/compile-fail/random_generator_no_copy_ctor.cpp
@@ -2,7 +2,7 @@
 
 // Distributed under the Boost Software License, Version 1.0. (See
 // accompanying file LICENSE_1_0.txt or copy at
-// http://www.boost.org/LICENSE_1_0.txt)
+// https://www.boost.org/LICENSE_1_0.txt)
 
 // The test verifies that random_generator is not copy constructible
 

--- a/test/compile/decl_header.cpp
+++ b/test/compile/decl_header.cpp
@@ -2,7 +2,7 @@
  *             Copyright Andrey Semashev 2015.
  * Distributed under the Boost Software License, Version 1.0.
  *    (See accompanying file LICENSE_1_0.txt or copy at
- *          http://www.boost.org/LICENSE_1_0.txt)
+ *          https://www.boost.org/LICENSE_1_0.txt)
  */
 /*!
  * \file   decl_header.cpp

--- a/test/compile_uuid.cpp
+++ b/test/compile_uuid.cpp
@@ -5,7 +5,7 @@
 
 // Distributed under the Boost Software License, Version 1.0. (See
 // accompanying file LICENSE_1_0.txt or copy at
-// http://www.boost.org/LICENSE_1_0.txt)
+// https://www.boost.org/LICENSE_1_0.txt)
 
 // Purpose to make sure that a translation unit consisting of just the contents
 // of the header file will compile successfully.

--- a/test/mock_random.cpp
+++ b/test/mock_random.cpp
@@ -3,7 +3,7 @@
 //
 // Distributed under the Boost Software License, Version 1.0.
 // (See accompanying file LICENSE_1_0.txt or copy at
-//   http://www.boost.org/LICENSE_1_0.txt)
+//   https://www.boost.org/LICENSE_1_0.txt)
 //
 // The contents of this file are compiled into a loadable
 // library that is used for mocking purposes so that the error

--- a/test/mock_random.cpp
+++ b/test/mock_random.cpp
@@ -3,7 +3,7 @@
 //
 // Distributed under the Boost Software License, Version 1.0.
 // (See accompanying file LICENSE_1_0.txt or copy at
-//   http://www.boost.org/LICENCE_1_0.txt)
+//   http://www.boost.org/LICENSE_1_0.txt)
 //
 // The contents of this file are compiled into a loadable
 // library that is used for mocking purposes so that the error

--- a/test/mock_random.hpp
+++ b/test/mock_random.hpp
@@ -3,7 +3,7 @@
 //
 // Distributed under the Boost Software License, Version 1.0.
 // (See accompanying file LICENSE_1_0.txt or copy at
-//   http://www.boost.org/LICENSE_1_0.txt)
+//   https://www.boost.org/LICENSE_1_0.txt)
 //
 // Mocks are used to test sad paths by forcing error responses
 //

--- a/test/mock_random.hpp
+++ b/test/mock_random.hpp
@@ -3,7 +3,7 @@
 //
 // Distributed under the Boost Software License, Version 1.0.
 // (See accompanying file LICENSE_1_0.txt or copy at
-//   http://www.boost.org/LICENCE_1_0.txt)
+//   http://www.boost.org/LICENSE_1_0.txt)
 //
 // Mocks are used to test sad paths by forcing error responses
 //

--- a/test/test_bench_random.cpp
+++ b/test/test_bench_random.cpp
@@ -3,7 +3,7 @@
 //
 // Distributed under the Boost Software License, Version 1.0.
 // (See accompanying file LICENSE_1_0.txt or copy at
-//   http://www.boost.org/LICENSE_1_0.txt)
+//   https://www.boost.org/LICENSE_1_0.txt)
 //
 // benchmark for random_generators in different forms
 //

--- a/test/test_bench_random.cpp
+++ b/test/test_bench_random.cpp
@@ -3,7 +3,7 @@
 //
 // Distributed under the Boost Software License, Version 1.0.
 // (See accompanying file LICENSE_1_0.txt or copy at
-//   http://www.boost.org/LICENCE_1_0.txt)
+//   http://www.boost.org/LICENSE_1_0.txt)
 //
 // benchmark for random_generators in different forms
 //

--- a/test/test_detail_random_provider.cpp
+++ b/test/test_detail_random_provider.cpp
@@ -3,7 +3,7 @@
 //
 // Distributed under the Boost Software License, Version 1.0.
 // (See accompanying file LICENSE_1_0.txt or copy at
-//   http://www.boost.org/LICENCE_1_0.txt)
+//   http://www.boost.org/LICENSE_1_0.txt)
 //
 // Positive and negative testing for detail::random_provider
 //

--- a/test/test_detail_random_provider.cpp
+++ b/test/test_detail_random_provider.cpp
@@ -3,7 +3,7 @@
 //
 // Distributed under the Boost Software License, Version 1.0.
 // (See accompanying file LICENSE_1_0.txt or copy at
-//   http://www.boost.org/LICENSE_1_0.txt)
+//   https://www.boost.org/LICENSE_1_0.txt)
 //
 // Positive and negative testing for detail::random_provider
 //

--- a/test/test_entropy_error.cpp
+++ b/test/test_entropy_error.cpp
@@ -3,7 +3,7 @@
 //
 // Distributed under the Boost Software License, Version 1.0.
 // (See accompanying file LICENSE_1_0.txt or copy at
-//   http://www.boost.org/LICENSE_1_0.txt)
+//   https://www.boost.org/LICENSE_1_0.txt)
 //
 // Entropy error class test
 //

--- a/test/test_entropy_error.cpp
+++ b/test/test_entropy_error.cpp
@@ -3,7 +3,7 @@
 //
 // Distributed under the Boost Software License, Version 1.0.
 // (See accompanying file LICENSE_1_0.txt or copy at
-//   http://www.boost.org/LICENCE_1_0.txt)
+//   http://www.boost.org/LICENSE_1_0.txt)
 //
 // Entropy error class test
 //

--- a/test/test_generators.cpp
+++ b/test/test_generators.cpp
@@ -5,7 +5,7 @@
 
 // Distributed under the Boost Software License, Version 1.0. (See
 // accompanying file LICENSE_1_0.txt or copy at
-// http://www.boost.org/LICENSE_1_0.txt)
+// https://www.boost.org/LICENSE_1_0.txt)
 
 //  libs/uuid/test/test_generators.cpp  -------------------------------//
 

--- a/test/test_hash.cpp
+++ b/test/test_hash.cpp
@@ -3,7 +3,7 @@
 //
 // Distributed under the Boost Software License, Version 1.0.
 // (See accompanying file LICENSE_1_0.txt or copy at
-//   http://www.boost.org/LICENCE_1_0.txt)
+//   http://www.boost.org/LICENSE_1_0.txt)
 //
 // std::hash support for uuid
 //

--- a/test/test_hash.cpp
+++ b/test/test_hash.cpp
@@ -3,7 +3,7 @@
 //
 // Distributed under the Boost Software License, Version 1.0.
 // (See accompanying file LICENSE_1_0.txt or copy at
-//   http://www.boost.org/LICENSE_1_0.txt)
+//   https://www.boost.org/LICENSE_1_0.txt)
 //
 // std::hash support for uuid
 //

--- a/test/test_include1.cpp
+++ b/test/test_include1.cpp
@@ -5,7 +5,7 @@
 
 // Distributed under the Boost Software License, Version 1.0. (See
 // accompanying file LICENSE_1_0.txt or copy at
-// http://www.boost.org/LICENSE_1_0.txt)
+// https://www.boost.org/LICENSE_1_0.txt)
 
 //  libs/uuid/test/test_include1.cpp  -------------------------------//
 

--- a/test/test_include2.cpp
+++ b/test/test_include2.cpp
@@ -5,7 +5,7 @@
 
 // Distributed under the Boost Software License, Version 1.0. (See
 // accompanying file LICENSE_1_0.txt or copy at
-// http://www.boost.org/LICENSE_1_0.txt)
+// https://www.boost.org/LICENSE_1_0.txt)
 
 //  libs/uuid/test/test_include2.cpp  -------------------------------//
 

--- a/test/test_io.cpp
+++ b/test/test_io.cpp
@@ -5,7 +5,7 @@
 
 // Distributed under the Boost Software License, Version 1.0. (See
 // accompanying file LICENSE_1_0.txt or copy at
-// http://www.boost.org/LICENSE_1_0.txt)
+// https://www.boost.org/LICENSE_1_0.txt)
 
 //  libs/uuid/test/test_io.cpp  -------------------------------//
 

--- a/test/test_md5.cpp
+++ b/test/test_md5.cpp
@@ -4,7 +4,7 @@
 
 // Distributed under the Boost Software License, Version 1.0. (See
 // accompanying file LICENSE_1_0.txt or copy at
-// http://www.boost.org/LICENSE_1_0.txt)
+// https://www.boost.org/LICENSE_1_0.txt)
 
 #include <boost/cstdint.hpp>
 #include <boost/detail/lightweight_test.hpp>

--- a/test/test_msvc_simd_bug981648.hpp
+++ b/test/test_msvc_simd_bug981648.hpp
@@ -3,7 +3,7 @@
 *
 * Distributed under the Boost Software License, Version 1.0.
 * See accompanying file LICENSE_1_0.txt or copy at
-* http://www.boost.org/LICENSE_1_0.txt
+* https://www.boost.org/LICENSE_1_0.txt
 */
 /*
 * This is a part of the test for a workaround for MSVC 12 (VS2013) optimizer bug

--- a/test/test_msvc_simd_bug981648_foo.cpp
+++ b/test/test_msvc_simd_bug981648_foo.cpp
@@ -3,7 +3,7 @@
 *
 * Distributed under the Boost Software License, Version 1.0.
 * See accompanying file LICENSE_1_0.txt or copy at
-* http://www.boost.org/LICENSE_1_0.txt
+* https://www.boost.org/LICENSE_1_0.txt
 */
 /*
 * This is a part of the test for a workaround for MSVC 12 (VS2013) optimizer bug

--- a/test/test_msvc_simd_bug981648_main.cpp
+++ b/test/test_msvc_simd_bug981648_main.cpp
@@ -3,7 +3,7 @@
 *
 * Distributed under the Boost Software License, Version 1.0.
 * See accompanying file LICENSE_1_0.txt or copy at
-* http://www.boost.org/LICENSE_1_0.txt
+* https://www.boost.org/LICENSE_1_0.txt
 */
 /*
 * This is a part of the test for a workaround for MSVC 12 (VS2013) optimizer bug

--- a/test/test_name_generator.cpp
+++ b/test/test_name_generator.cpp
@@ -5,7 +5,7 @@
 
 // Distributed under the Boost Software License, Version 1.0. (See
 // accompanying file LICENSE_1_0.txt or copy at
-// http://www.boost.org/LICENSE_1_0.txt)
+// https://www.boost.org/LICENSE_1_0.txt)
 
 //  libs/uuid/test/test_name_generator.cpp  -------------------------------//
 

--- a/test/test_nil_generator.cpp
+++ b/test/test_nil_generator.cpp
@@ -5,7 +5,7 @@
 
 // Distributed under the Boost Software License, Version 1.0. (See
 // accompanying file LICENSE_1_0.txt or copy at
-// http://www.boost.org/LICENSE_1_0.txt)
+// https://www.boost.org/LICENSE_1_0.txt)
 
 //  libs/uuid/test/test_nil_generator.cpp  -------------------------------//
 

--- a/test/test_random_generator.cpp
+++ b/test/test_random_generator.cpp
@@ -5,7 +5,7 @@
 
 // Distributed under the Boost Software License, Version 1.0. (See
 // accompanying file LICENSE_1_0.txt or copy at
-// http://www.boost.org/LICENSE_1_0.txt)
+// https://www.boost.org/LICENSE_1_0.txt)
 
 //  libs/uuid/test/test_random_generator.cpp  -------------------------------//
 

--- a/test/test_serialization.cpp
+++ b/test/test_serialization.cpp
@@ -5,7 +5,7 @@
 
 // Distributed under the Boost Software License, Version 1.0. (See
 // accompanying file LICENSE_1_0.txt or copy at
-// http://www.boost.org/LICENSE_1_0.txt)
+// https://www.boost.org/LICENSE_1_0.txt)
 
 // Purpose to test serializing uuids with narrow archives
 

--- a/test/test_sha1.cpp
+++ b/test/test_sha1.cpp
@@ -5,7 +5,7 @@
 
 // Distributed under the Boost Software License, Version 1.0. (See
 // accompanying file LICENSE_1_0.txt or copy at
-// http://www.boost.org/LICENSE_1_0.txt)
+// https://www.boost.org/LICENSE_1_0.txt)
 
 //  libs/uuid/test/test_sha1.cpp  -------------------------------//
 

--- a/test/test_string_generator.cpp
+++ b/test/test_string_generator.cpp
@@ -5,7 +5,7 @@
 
 // Distributed under the Boost Software License, Version 1.0. (See
 // accompanying file LICENSE_1_0.txt or copy at
-// http://www.boost.org/LICENSE_1_0.txt)
+// https://www.boost.org/LICENSE_1_0.txt)
 
 //  libs/uuid/test/test_string_generator.cpp  -------------------------------//
 

--- a/test/test_tagging.cpp
+++ b/test/test_tagging.cpp
@@ -5,7 +5,7 @@
 
 // Distributed under the Boost Software License, Version 1.0. (See
 // accompanying file LICENSE_1_0.txt or copy at
-// http://www.boost.org/LICENSE_1_0.txt)
+// https://www.boost.org/LICENSE_1_0.txt)
 
 //  libs/uuid/test/test_tagging.cpp  -------------------------------//
 

--- a/test/test_uuid.cpp
+++ b/test/test_uuid.cpp
@@ -5,7 +5,7 @@
 
 // Distributed under the Boost Software License, Version 1.0. (See
 // accompanying file LICENSE_1_0.txt or copy at
-// http://www.boost.org/LICENSE_1_0.txt)
+// https://www.boost.org/LICENSE_1_0.txt)
 
 //  libs/uuid/test/test_uuid.cpp  -------------------------------//
 

--- a/test/test_uuid_class.cpp
+++ b/test/test_uuid_class.cpp
@@ -5,7 +5,7 @@
 
 // Distributed under the Boost Software License, Version 1.0. (See
 // accompanying file LICENSE_1_0.txt or copy at
-// http://www.boost.org/LICENSE_1_0.txt)
+// https://www.boost.org/LICENSE_1_0.txt)
 
 //  libs/uuid/test/test_uuid_class.cpp  -------------------------------//
 

--- a/test/test_uuid_in_map.cpp
+++ b/test/test_uuid_in_map.cpp
@@ -5,7 +5,7 @@
 
 // Distributed under the Boost Software License, Version 1.0. (See
 // accompanying file LICENSE_1_0.txt or copy at
-// http://www.boost.org/LICENSE_1_0.txt)
+// https://www.boost.org/LICENSE_1_0.txt)
 
 // libs/uuid/test/test_uuid_in_map.cpp  -------------------------------//
 

--- a/test/test_uuid_no_simd.cpp
+++ b/test/test_uuid_no_simd.cpp
@@ -5,7 +5,7 @@
 
 // Distributed under the Boost Software License, Version 1.0. (See
 // accompanying file LICENSE_1_0.txt or copy at
-// http://www.boost.org/LICENSE_1_0.txt)
+// https://www.boost.org/LICENSE_1_0.txt)
 
 //  libs/uuid/test/test_uuid_no_simd.cpp  -------------------------------//
 

--- a/test/test_wserialization.cpp
+++ b/test/test_wserialization.cpp
@@ -5,7 +5,7 @@
 
 // Distributed under the Boost Software License, Version 1.0. (See
 // accompanying file LICENSE_1_0.txt or copy at
-// http://www.boost.org/LICENSE_1_0.txt)
+// https://www.boost.org/LICENSE_1_0.txt)
 
 // Purpose to test serializing uuids with wide stream archives
 


### PR DESCRIPTION
Hi, this PR is intentionally split into two commits in case I've overlooked some reason that speaks against the second one. The first one fixes some links that pointed to http://www.boost.org/LICENCE_1_0.txt rather than http://www.boost.org/LICENSE_1_0.txt which causes a 404 when clicked in the online documentation or copied into the URL field. The second one changes all occurrences of that link to https, which saves a redirection when clicked.