### PR TITLE
Improvements to CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -95,6 +95,7 @@ anchors:
   gcc-6:    &gcc-6    { apt: { packages: [ "g++-6"           ], sources: [ "ubuntu-toolchain-r-test"   ] } }
   gcc-7:    &gcc-7    { apt: { packages: [ "g++-7"           ], sources: [ "ubuntu-toolchain-r-test"   ] } }
   gcc-8:    &gcc-8    { apt: { packages: [ "g++-8"           ], sources: [ "ubuntu-toolchain-r-test"   ] } }
+  gcc-9:    &gcc-9    { apt: { packages: [ "g++-9"           ], sources: [ "ubuntu-toolchain-r-test"   ] } }
 
 jobs:
   allow_failures:
@@ -108,6 +109,7 @@ jobs:
     - { os: "linux", env: [ "B2_TOOLSET=gcc-6",       "B2_CXXSTD=11,14"    ], addons: *gcc-6     }
     - { os: "linux", env: [ "B2_TOOLSET=gcc-7",       "B2_CXXSTD=11,14,17" ], addons: *gcc-7     }
     - { os: "linux", env: [ "B2_TOOLSET=gcc-8",       "B2_CXXSTD=14,17,2a" ], addons: *gcc-8     }
+    - { os: "linux", env: [ "B2_TOOLSET=gcc-9",       "B2_CXXSTD=14,17,2a" ], addons: *gcc-9     }
     - { os: "linux", env: [ "B2_TOOLSET=clang-3.8",   "B2_CXXSTD=03,11,14" ], addons: *clang-38  }
     - { os: "linux", env: [ "B2_TOOLSET=clang-4.0",   "B2_CXXSTD=11,14"    ], addons: *clang-4   }
     - { os: "linux", env: [ "B2_TOOLSET=clang-5.0",   "B2_CXXSTD=11,14,17" ], addons: *clang-5   }
@@ -132,7 +134,6 @@ jobs:
         - B2_DEFINES="define=BOOST_NO_STRESS_TEST=1"
       addons: *gcc-8
       script:
-        - pushd /tmp && git clone https://github.com/linux-test-project/lcov.git && export PATH=/tmp/lcov/bin:$PATH && which lcov && lcov --version && popd
         - cd $BOOST_ROOT/libs/$SELF
         - ci/travis/codecov.sh
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -28,11 +28,10 @@ language: cpp
 env:
   global:
   # see: http://www.boost.org/build/doc/html/bbv2/overview/invocation.html#bbv2.overview.invocation.properties
-  # to use the default for a given environment, comment it out; recommend you build debug and release however..
   # - B2_ADDRESS_MODEL=address-model=64,32
   # - B2_LINK=link=shared,static
   # - B2_THREADING=threading=multi,single
-    - B2_VARIANT=variant=release,debug
+    - B2_VARIANT=variant=release
 
 install:
   - git clone https://github.com/boostorg/boost-ci.git boost-ci
@@ -48,8 +47,12 @@ addons:
 
 branches:
   only:
-    - develop
     - master
+    - develop
+    - /bugfix\/.*/
+    - /feature\/.*/
+    - /fix\/.*/
+    - /pr\/.*/
 
 script:
   - cd $BOOST_ROOT/libs/$SELF
@@ -91,6 +94,7 @@ anchors:
                                            "libstdc++-8-dev" ], sources: [ "llvm-toolchain-xenial-8",
                                                                            "ubuntu-toolchain-r-test"   ] } }
   gcc-48:   &gcc-48   { apt: { packages: [ "g++-4.8"         ]                                           } }
+  gcc-49:   &gcc-49   { apt: { packages: [ "g++-4.9"         ], sources: [ "ubuntu-toolchain-r-test"   ] } }
   gcc-5:    &gcc-5    { apt: { packages: [ "g++-5"           ]                                           } }
   gcc-6:    &gcc-6    { apt: { packages: [ "g++-6"           ], sources: [ "ubuntu-toolchain-r-test"   ] } }
   gcc-7:    &gcc-7    { apt: { packages: [ "g++-7"           ], sources: [ "ubuntu-toolchain-r-test"   ] } }
@@ -104,21 +108,25 @@ jobs:
 
   include:
     # libstdc++
-    - { os: "linux", env: [ "B2_TOOLSET=gcc-4.8",     "B2_CXXSTD=03,11"    ], addons: *gcc-48    }
-    - { os: "linux", env: [ "B2_TOOLSET=gcc-5",       "B2_CXXSTD=11"       ], addons: *gcc-5     }
+    - { os: "linux", dist: "trusty",  # xenial has libstdc++ from gcc 5.4.0 with newer ABI
+                     env: [ "B2_TOOLSET=gcc-4.8",     "B2_CXXSTD=03,11"    ], addons: *gcc-48    }
+    - { os: "linux", dist: "trusty",  # xenial has libstdc++ from gcc 5.4.0 with newer ABI
+                     env: [ "B2_TOOLSET=gcc-4.9",     "B2_CXXSTD=03,11"    ], addons: *gcc-49    }
+    - { os: "linux", env: [ "B2_TOOLSET=gcc-5",       "B2_CXXSTD=03,11"    ], addons: *gcc-5     }
     - { os: "linux", env: [ "B2_TOOLSET=gcc-6",       "B2_CXXSTD=11,14"    ], addons: *gcc-6     }
-    - { os: "linux", env: [ "B2_TOOLSET=gcc-7",       "B2_CXXSTD=11,14,17" ], addons: *gcc-7     }
-    - { os: "linux", env: [ "B2_TOOLSET=gcc-8",       "B2_CXXSTD=14,17,2a" ], addons: *gcc-8     }
-    - { os: "linux", env: [ "B2_TOOLSET=gcc-9",       "B2_CXXSTD=14,17,2a" ], addons: *gcc-9     }
-    - { os: "linux", env: [ "B2_TOOLSET=clang-3.8",   "B2_CXXSTD=03,11,14" ], addons: *clang-38  }
+    - { os: "linux", env: [ "B2_TOOLSET=gcc-7",       "B2_CXXSTD=14,17"    ], addons: *gcc-7     }
+    - { os: "linux", env: [ "B2_TOOLSET=gcc-8",       "B2_CXXSTD=17,2a"    ], addons: *gcc-8     }
+    - { os: "linux", env: [ "B2_TOOLSET=gcc-9",       "B2_CXXSTD=17,2a"    ], addons: *gcc-9     }
+    - { os: "linux", dist: "trusty",  # xenial has libstdc++ from gcc 5.4.0 with newer ABI
+                     env: [ "B2_TOOLSET=clang-3.8",   "B2_CXXSTD=03,11"    ], addons: *clang-38  }
     - { os: "linux", env: [ "B2_TOOLSET=clang-4.0",   "B2_CXXSTD=11,14"    ], addons: *clang-4   }
-    - { os: "linux", env: [ "B2_TOOLSET=clang-5.0",   "B2_CXXSTD=11,14,17" ], addons: *clang-5   }
-    - { os: "linux", env: [ "B2_TOOLSET=clang-6.0",   "B2_CXXSTD=14,17,2a" ], addons: *clang-6   }
-    - { os: "linux", env: [ "B2_TOOLSET=clang-7",     "B2_CXXSTD=14,17,2a" ], addons: *clang-7   }
-    - { os: "linux", env: [ "B2_TOOLSET=clang-8",     "B2_CXXSTD=14,17,2a" ], addons: *clang-8   }
+    - { os: "linux", env: [ "B2_TOOLSET=clang-5.0",   "B2_CXXSTD=11,14"    ], addons: *clang-5   }
+    - { os: "linux", env: [ "B2_TOOLSET=clang-6.0",   "B2_CXXSTD=14,17"    ], addons: *clang-6   }
+    - { os: "linux", env: [ "B2_TOOLSET=clang-7",     "B2_CXXSTD=17,2a"    ], addons: *clang-7   }
+    - { os: "linux", env: [ "B2_TOOLSET=clang-8",     "B2_CXXSTD=17,2a"    ], addons: *clang-8   }
 
     # libc++
-    - { os: "linux", env: [ "B2_TOOLSET=clang-6.0",   "B2_CXXSTD=03,11,14,17,2a",
+    - { os: "linux", env: [ "B2_TOOLSET=clang-6.0",   "B2_CXXSTD=03,11,14",
                             "B2_CXXFLAGS=-stdlib=libc++"                   ], addons: *clang-6   }
     - { os: "osx"  , env: [ "B2_TOOLSET=clang",       "B2_CXXSTD=03,11,17" ]                     }
 
@@ -139,17 +147,10 @@ jobs:
 
     - os: linux
       env:
-        - COMMENT=cppcheck
-      script:
-        - cd $BOOST_ROOT/libs/$SELF
-        - ci/travis/cppcheck.sh
-
-    - os: linux
-      env:
         - COMMENT=ubsan
         - B2_VARIANT=variant=debug
         - B2_TOOLSET=gcc-8
-        - B2_CXXSTD=03,11,14,17,2a
+        - B2_CXXSTD=03,11,14
         - B2_DEFINES="define=BOOST_NO_STRESS_TEST=1"
         - B2_CXXFLAGS="cxxflags=-fno-omit-frame-pointer cxxflags=-fsanitize=undefined cxxflags=-fno-sanitize-recover=undefined"
         - B2_LINKFLAGS="linkflags=-fsanitize=undefined linkflags=-fno-sanitize-recover=undefined linkflags=-fuse-ld=gold"
@@ -160,7 +161,7 @@ jobs:
       env:
         - COMMENT=valgrind
         - B2_TOOLSET=clang-6.0
-        - B2_CXXSTD=03,11,14,17,2a
+        - B2_CXXSTD=03,11,14
         - B2_DEFINES="define=BOOST_NO_STRESS_TEST=1"
         - B2_VARIANT=variant=debug
         - B2_TESTFLAGS=testing.launcher=valgrind
@@ -169,6 +170,13 @@ jobs:
       script:
         - cd $BOOST_ROOT/libs/$SELF
         - ci/travis/valgrind.sh
+
+    # - os: linux
+    #   env:
+    #     - COMMENT=cppcheck
+    #   script:
+    #     - cd $BOOST_ROOT/libs/$SELF
+    #     - ci/travis/cppcheck.sh
 
     #################### Jobs to run on pushes to master, develop ###################
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -25,8 +25,12 @@ shallow_clone: true
 
 branches:
   only:
-    - develop
     - master
+    - develop
+    - /bugfix\/.*/
+    - /feature\/.*/
+    - /fix\/.*/
+    - /pr\/.*/
 
 matrix:
   # Adding MAYFAIL to any matrix job allows it to fail but the build stays green:
@@ -42,7 +46,7 @@ environment:
     # B2_ADDRESS_MODEL: address-model=64,32
     # B2_LINK: link=shared,static
     # B2_THREADING: threading=multi,single
-    B2_VARIANT: variant=release,debug
+    B2_VARIANT: variant=release
 
   matrix:
     - FLAVOR: Visual Studio 2019
@@ -65,6 +69,7 @@ environment:
       B2_ADDRESS_MODEL: address-model=64
       B2_CXXSTD: 17
       B2_TOOLSET: msvc-14.1
+      B2_VARIANT: variant=debug
 
     - FLAVOR: Visual Studio 2017 C++14 (Default)
       APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2017
@@ -75,6 +80,7 @@ environment:
       APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2015
       B2_ADDRESS_MODEL: address-model=64,32
       B2_TOOLSET: msvc-14.0
+      B2_VARIANT: variant=debug
 
     - FLAVOR: Visual Studio 2010, 2012, 2013
       APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2015
@@ -89,6 +95,7 @@ environment:
       B2_DEFINES: define=_POSIX_C_SOURCE=200112L
       B2_THREADING: threadapi=pthread
       B2_TOOLSET: gcc
+      B2_VARIANT: variant=debug
 
     - FLAVOR: cygwin (64-bit)
       APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2017
@@ -106,6 +113,7 @@ environment:
       B2_ADDRESS_MODEL: address-model=32
       B2_CXXSTD: 03,11
       SCRIPT: ci\appveyor\mingw.bat
+      B2_VARIANT: variant=debug
 
     - FLAVOR: mingw64
       APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2017

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -45,6 +45,14 @@ environment:
     B2_VARIANT: variant=release,debug
 
   matrix:
+    - FLAVOR: Visual Studio 2019
+      APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2019
+      B2_ADDRESS_MODEL: address-model=64
+      B2_CXXFLAGS: cxxflags=-permissive-
+      B2_CXXSTD: latest # 2a
+      B2_TOOLSET: msvc-14.2
+      MAYFAIL: true
+
     - FLAVOR: Visual Studio 2017 C++2a Strict
       APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2017
       B2_ADDRESS_MODEL: address-model=64


### PR DESCRIPTION
This adds some new compilers and reduces the overall workload of the CI by cutting back the number of cxxstd and variant combinations in total.

- Add Visual Studio 2019 on AppVeyor
- Add gcc-9 on Travis
- Reduce the cxxstd matrix to 2 choices on most Travis CI jobs
- Build mostly release variant with a few debug variants sprinkled in
- Disable cppcheck builds as they are hanging on some repositories