### PR TITLE
Fixed issues with linking with external 3rd parties on Windows

### DIFF
--- a/include/boost/uuid/detail/random_provider_bcrypt.ipp
+++ b/include/boost/uuid/detail/random_provider_bcrypt.ipp
@@ -18,13 +18,11 @@
 #include <boost/throw_exception.hpp>
 
 #if defined(BOOST_UUID_FORCE_AUTO_LINK) || (!defined(BOOST_ALL_NO_LIB) && !defined(BOOST_UUID_RANDOM_PROVIDER_NO_LIB))
-#   define BOOST_LIB_NAME "bcrypt"
-#   if defined(BOOST_AUTO_LINK_NOMANGLE)
-#      include <boost/config/auto_link.hpp>
-#   else
-#      define BOOST_AUTO_LINK_NOMANGLE
-#      include <boost/config/auto_link.hpp>
-#      undef BOOST_AUTO_LINK_NOMANGLE
+#   if defined(BOOST_MSVC) \
+     || defined(__BORLANDC__) \
+     || (defined(__MWERKS__) && defined(_WIN32) && (__MWERKS__ >= 0x3000)) \
+     || (defined(__ICL) && defined(_MSC_EXTENSIONS) && (_MSC_VER >= 1200))
+#      pragma comment(lib, "bcrypt.lib")
 #   endif
 #endif
 

--- a/include/boost/uuid/detail/random_provider_wincrypt.ipp
+++ b/include/boost/uuid/detail/random_provider_wincrypt.ipp
@@ -22,17 +22,15 @@
 #include <boost/throw_exception.hpp>
 
 #if defined(BOOST_UUID_FORCE_AUTO_LINK) || (!defined(BOOST_ALL_NO_LIB) && !defined(BOOST_UUID_RANDOM_PROVIDER_NO_LIB))
-#   if defined(_WIN32_WCE)
-#      define BOOST_LIB_NAME "coredll"
-#   else
-#      define BOOST_LIB_NAME "advapi32"
-#   endif
-#   if defined(BOOST_AUTO_LINK_NOMANGLE)
-#      include <boost/config/auto_link.hpp>
-#   else
-#      define BOOST_AUTO_LINK_NOMANGLE
-#      include <boost/config/auto_link.hpp>
-#      undef BOOST_AUTO_LINK_NOMANGLE
+#   if defined(BOOST_MSVC) \
+     || defined(__BORLANDC__) \
+     || (defined(__MWERKS__) && defined(_WIN32) && (__MWERKS__ >= 0x3000)) \
+     || (defined(__ICL) && defined(_MSC_EXTENSIONS) && (_MSC_VER >= 1200))
+#      if defined(_WIN32_WCE)
+#         pragma comment(lib, "coredll.lib")
+#      else
+#         pragma comment(lib, "advapi32.lib")
+#      endif
 #   endif
 #endif
 


### PR DESCRIPTION
Hi,
Currently, when enabling BOOST_AUTO_LINK_TAGGED or BOOST_AUTO_LINK_SYSTEM, the build with boost fails because auto_link is used for non boost libraries (Windows libraries) : bcrypt.lib, coredll.lib and advapi32.lib. Boost auto_link seems to be restricted to boost libraries as it constructs library name depending on Boost options. Since these Windows libs does not follow boost naming convention so auto_link shouldn't be used for thoses.

This has already been discussed : https://github.com/boostorg/uuid/pull/95#issuecomment-514135091and https://github.com/boostorg/uuid/issues/94.

Regards,
Colin Chargy