### PR TITLE
Add missing headers

### DIFF
--- a/include/boost/uuid/detail/uuid_x86.ipp
+++ b/include/boost/uuid/detail/uuid_x86.ipp
@@ -39,6 +39,10 @@ extern "C" void _ReadWriteBarrier(void);
 #endif
 #endif
 
+#include <boost/config.hpp>
+#include <boost/cstdint.hpp>
+#include <boost/uuid/uuid.hpp>
+
 namespace boost {
 namespace uuids {
 namespace detail {


### PR DESCRIPTION
This makes the header be able to build standalone, making possible C++ clang modules builds.