### PR TITLE
Link bcrypt in CMake tests on MSVC

### DIFF
--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -4,8 +4,6 @@
 
 include(BoostTest OPTIONAL RESULT_VARIABLE HAVE_BOOST_TEST)
 
-include(BoostTest OPTIONAL RESULT_VARIABLE HAVE_BOOST_TEST)
-
 if(NOT HAVE_BOOST_TEST)
   return()
 endif()
@@ -20,12 +18,12 @@ boost_test(TYPE run SOURCES test_io.cpp LINK_LIBRARIES Boost::lexical_cast)
 boost_test(TYPE run SOURCES test_nil_generator.cpp)
 boost_test(TYPE run SOURCES test_name_generator.cpp)
 boost_test(TYPE run SOURCES test_string_generator.cpp)
-boost_test(TYPE run SOURCES test_random_generator.cpp)
+boost_test(TYPE run SOURCES test_random_generator.cpp LINK_LIBRARIES $<$<CXX_COMPILER_ID:MSVC>:bcrypt>)
 
-boost_test(TYPE run SOURCES test_tagging.cpp)
+boost_test(TYPE run SOURCES test_tagging.cpp LINK_LIBRARIES $<$<CXX_COMPILER_ID:MSVC>:bcrypt>)
 
-boost_test(TYPE run SOURCES test_uuid_class.cpp)
-boost_test(TYPE run SOURCES test_uuid_in_map.cpp)
+boost_test(TYPE run SOURCES test_uuid_class.cpp LINK_LIBRARIES $<$<CXX_COMPILER_ID:MSVC>:bcrypt>)
+boost_test(TYPE run SOURCES test_uuid_in_map.cpp LINK_LIBRARIES $<$<CXX_COMPILER_ID:MSVC>:bcrypt>)
 
 boost_test(TYPE run SOURCES test_hash.cpp)
 boost_test(TYPE run SOURCES test_md5.cpp)
@@ -33,6 +31,6 @@ boost_test(TYPE run SOURCES test_sha1.cpp)
 
 boost_test(TYPE run SOURCES test_entropy_error.cpp)
 
-boost_test(TYPE run SOURCES test_detail_random_provider.cpp)
+boost_test(TYPE run SOURCES test_detail_random_provider.cpp LINK_LIBRARIES $<$<CXX_COMPILER_ID:MSVC>:bcrypt>)
 
 boost_test(TYPE run SOURCES test_serialization.cpp LINK_LIBRARIES Boost::serialization)


### PR DESCRIPTION
See boostorg/uuid#68, boostorg/uuid#78, boostorg/uuid#122, related boostorg/boost_install#54.

---

@pdimov I think you unintentionally broke the cmake tests for 1.85.0 on msvc; given you're involved in the above linked issues ;)

Needed for orgs/individuals that run boost tests in CI, e.g., sanity check to verify that internal / to-be-upstreamed patches haven't broken other behavior.