### PR TITLE
Align `boost::uuid` to 16 bytes

### DIFF
--- a/include/boost/uuid/uuid.hpp
+++ b/include/boost/uuid/uuid.hpp
@@ -59,6 +59,14 @@ private:
 
 #if !defined(BOOST_UUID_DISABLE_ALIGNMENT)
 
+#if (defined(__SIZEOF_POINTER__) && (__SIZEOF_POINTER__ >= 8)) || \
+    defined(__x86_64__) /* This covers x86-x32 */ || \
+    defined(_M_AMD64) || defined(_M_ARM64)
+            // Align uuid objects to 16 bytes on 64-bit platforms for performance.
+            // On most 32-bit platforms, default stack and dynamic memory alignment is lower than 16
+            // (typically 4 or 8), which makes it problematic to require uuid alignment of 16.
+            BOOST_ALIGNMENT(16)
+#endif
             std::uint64_t align_u64_;
 
 #endif


### PR DESCRIPTION
This improves performance of operations on UUIDs as the UUID object now does not(*) cross page boundary. It may also improve code generation by compilers, which can now assume that loads and stores of UUIDs are not as expensive and therefore it may be more preferable to use vector instructions for that.

(*) It is technically possible that the `boost::uuid` object is still not properly aligned under some conditions. For example, on some 32-bit targets the stack is not aligned to 16 bytes, so placing the UUID object on the unaligned stack may result in unaligned UUID. For this reason, this commit does not change the SIMD intrinsics used in `boost::uuid` operations to their aligned equivalents. Using unaligned load/store instructions on actually aligned memory location on modern CPUs has the same performance as using aligned instructions, so the performance benefit is still there.

Closes https://github.com/boostorg/uuid/issues/139.