### PR TITLE
Add AVX-512/AVX10.1 implementation of `operator<`/`operator<=>`

### DIFF
--- a/doc/uuid/configuration.adoc
+++ b/doc/uuid/configuration.adoc
@@ -11,18 +11,24 @@ The library does not require building or any special configuration to be used. H
 |Macro |Description
 
 |`BOOST_UUID_NO_SIMD`
-|If defined, disables any optimizations for http://en.wikipedia.org/wiki/SIMD[SIMD]-enabled processors. Generic versions of algorithms will be used instead. This may result in suboptimal performance. By default, optimized algorithms are used, when the library is able to detect the availability of SIMD extensions at compile time.
+|If defined, disables any optimizations for https://en.wikipedia.org/wiki/SIMD[SIMD]-enabled processors. Generic versions of algorithms will be used instead. This may result in suboptimal performance. By default, optimized algorithms are used, when the library is able to detect the availability of SIMD extensions at compile time.
 
 
 |`BOOST_UUID_USE_SSE2`
-|If defined, enables optimizations for http://en.wikipedia.org/wiki/SSE2[SSE2] exstensions available in modern x86 processors.
+|If defined, enables optimizations for https://en.wikipedia.org/wiki/SSE2[SSE2] exstensions available in x86 processors.
 
 |`BOOST_UUID_USE_SSE3`
-|If defined, enables optimizations for http://en.wikipedia.org/wiki/SSE3[SSE3] exstensions available in modern x86 processors.
+|If defined, enables optimizations for https://en.wikipedia.org/wiki/SSE3[SSE3] exstensions available in x86 processors.
 
 |`BOOST_UUID_USE_SSE41`
-|If defined, enables optimizations for http://en.wikipedia.org/wiki/SSE4#SSE4.1[SSE4.1] exstensions available in modern x86 processors.
+|If defined, enables optimizations for https://en.wikipedia.org/wiki/SSE4#SSE4.1[SSE4.1] exstensions available in x86 processors.
+
+|`BOOST_UUID_USE_AVX`
+|If defined, enables optimizations for https://en.wikipedia.org/wiki/Advanced_Vector_Extensions[AVX] exstensions available in modern x86 processors.
+
+|`BOOST_UUID_USE_AVX10_1`
+|If defined, enables optimizations for https://en.wikipedia.org/wiki/AVX-512[AVX-512] and https://en.wikipedia.org/wiki/Advanced_Vector_Extensions#AVX10[AVX10.1] exstensions available in modern x86 processors. The library does not require 512-bit vectors and is compatible with CPUs implementing AVX-512F, CD, VL, BW and DQ instruction subsets (i.e. equivalent to Intel Skylake-X).
 
 |===
 
-By default the library attempts to detect the availability of SIMD extensions in the target CPU at compile time and automatically defines the appropriate macros if succeeded. The `BOOST_UUID_USE_SSE*` macros can be defined by users, if auto-detection fails and it is known that the target CPU will have the extension. Do not enable these extensions unless you're certain that they will always be available on any machine that will run your program. The library performs no run time checks, so if an extension is missing, the program will likely crash. Note that enabling more advanced extensions implies that more basic ones are also available.
+By default the library attempts to detect the availability of SIMD extensions in the target CPU at compile time and automatically defines the appropriate macros if succeeded. The `BOOST_UUID_USE_SSE*` and `BOOST_UUID_USE_AVX*` macros can be defined by users, if auto-detection fails and it is known that the target CPU will have the extension. Do not enable these extensions unless you're certain that they will always be available on any machine that will run your program. The library performs no run time checks, so if an extension is missing, the program will likely crash. Note that enabling more advanced extensions implies that more basic ones are also available.

--- a/include/boost/uuid/detail/config.hpp
+++ b/include/boost/uuid/detail/config.hpp
@@ -40,30 +40,31 @@
 #define BOOST_UUID_USE_AVX
 #endif
 
+#if ((defined(__AVX512F__) && defined(__AVX512VL__) && defined(__AVX512BW__)) || defined(__AVX10_1__)) && !defined(BOOST_UUID_USE_AVX10_1)
+#define BOOST_UUID_USE_AVX10_1
+#endif
+
 #elif defined(_MSC_VER)
 
 #if (defined(_M_X64) || (defined(_M_IX86) && defined(_M_IX86_FP) && _M_IX86_FP >= 2)) && !defined(BOOST_UUID_USE_SSE2)
 #define BOOST_UUID_USE_SSE2
 #endif
 
-#if defined(__AVX__)
-#if !defined(BOOST_UUID_USE_AVX)
+#if defined(__AVX__) && !defined(BOOST_UUID_USE_AVX)
 #define BOOST_UUID_USE_AVX
 #endif
-#if !defined(BOOST_UUID_USE_SSE41)
-#define BOOST_UUID_USE_SSE41
-#endif
-#if !defined(BOOST_UUID_USE_SSE3)
-#define BOOST_UUID_USE_SSE3
-#endif
-#if !defined(BOOST_UUID_USE_SSE2)
-#define BOOST_UUID_USE_SSE2
-#endif
+
+#if ((defined(__AVX512F__) && defined(__AVX512VL__) && defined(__AVX512BW__)) || defined(__AVX10_1__)) && !defined(BOOST_UUID_USE_AVX10_1)
+#define BOOST_UUID_USE_AVX10_1
 #endif
 
 #endif
 
 // More advanced ISA extensions imply less advanced are also available
+#if !defined(BOOST_UUID_USE_AVX) && defined(BOOST_UUID_USE_AVX10_1)
+#define BOOST_UUID_USE_AVX
+#endif
+
 #if !defined(BOOST_UUID_USE_SSE41) && defined(BOOST_UUID_USE_AVX)
 #define BOOST_UUID_USE_SSE41
 #endif
@@ -77,6 +78,7 @@
 #endif
 
 #if !defined(BOOST_UUID_NO_SIMD) && \
+    !defined(BOOST_UUID_USE_AVX10_1) && \
     !defined(BOOST_UUID_USE_AVX) && \
     !defined(BOOST_UUID_USE_SSE41) && \
     !defined(BOOST_UUID_USE_SSE3) && \


### PR DESCRIPTION
The new implementation offers about 20% speed improvement over the SSE2 version on i7 12700K, and about 30% over the `uint128_t`-based version.

Also added GitHub CI jobs with AVX-512 enabled to test the new implementation.
