### PR TITLE
Update actions/checkout in GitHub Actions to v4

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -232,7 +232,7 @@ jobs:
         shell: bash
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       - name: Setup container environment
         if: matrix.container


### PR DESCRIPTION
This updates [actions/checkout](https://github.com/actions/checkout) in the GitHub Actions workflow to v4.

Still using the older v3 will generate warnings in CI runs, for example in https://github.com/boostorg/uuid/actions/runs/8901444927:

> Node.js 16 actions are deprecated. Please update the following actions to use Node.js 20: actions/checkout@v3. For more information see: https://github.blog/changelog/2023-09-22-github-actions-transitioning-from-node-16-to-node-20/.

The PR will get rid of those warnings.