### PR TITLE
GHA: Remove actions/checkout, fix apt commands, add retries on net errors

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,6 +9,8 @@ on:
       - feature/**
 
 env:
+  GIT_FETCH_JOBS: 8
+  NET_RETRY_COUNT: 5
   UBSAN_OPTIONS: print_stacktrace=1
 
 jobs:
@@ -229,23 +231,17 @@ jobs:
         shell: bash
 
     steps:
-      - name: Enable Node 16
-        run: |
-          echo "ACTIONS_ALLOW_USE_UNSECURE_NODE_VERSION=true" >> $GITHUB_ENV
-
-      - uses: actions/checkout@v3
-
       - name: Setup container environment
         if: matrix.container
         run: |
-          apt-get update
-          apt-get -y install sudo python3 git g++
+          apt-get -o Acquire::Retries=$NET_RETRY_COUNT update
+          apt-get -o Acquire::Retries=$NET_RETRY_COUNT -y install sudo python3 git curl g++
 
       - name: Install packages
         if: matrix.install
         run: |
-          sudo apt-get update
-          sudo apt-get -y install ${{join(matrix.install, ' ')}}
+          sudo apt-get -o Acquire::Retries=$NET_RETRY_COUNT update
+          sudo apt-get -o Acquire::Retries=$NET_RETRY_COUNT -y install ${{join(matrix.install, ' ')}}
 
       - name: Setup Boost
         run: |
@@ -260,12 +256,57 @@ jobs:
           echo REF: $REF
           BOOST_BRANCH=develop && [ "$REF" == "master" ] && BOOST_BRANCH=master || true
           echo BOOST_BRANCH: $BOOST_BRANCH
+          DEPINST_ARGS=()
+          GIT_VERSION="$(git --version | sed -e 's/git version //')"
+          GIT_HAS_JOBS=1
+          if [ -f "/etc/debian_version" ]
+          then
+              if $(dpkg --compare-versions "$GIT_VERSION" lt 2.8.0)
+              then
+                  GIT_HAS_JOBS=0
+              fi
+          else
+              declare -a GIT_VER=(${GIT_VERSION//./ })
+              declare -a GIT_MIN_VER=(2 8 0)
+              for ((i=0; i<${#GIT_VER[@]}; i++))
+              do
+                  if [ -z "${GIT_MIN_VER[i]}" ]
+                  then
+                      GIT_MIN_VER[i]=0
+                  fi
+                  if [ "${GIT_VER[i]}" -lt "${GIT_MIN_VER[i]}" ]
+                  then
+                      GIT_HAS_JOBS=0
+                      break
+                  fi
+              done
+          fi
+          if [ "$GIT_HAS_JOBS" -ne 0 ]
+          then
+              DEPINST_ARGS+=("--git_args" "--jobs $GIT_FETCH_JOBS")
+          fi
+          mkdir -p snapshot
+          cd snapshot
+          echo "Downloading library snapshot: https://github.com/${GITHUB_REPOSITORY}/archive/${GITHUB_SHA}.tar.gz"
+          curl -L --retry "$NET_RETRY_COUNT" -o "${LIBRARY}-${GITHUB_SHA}.tar.gz" "https://github.com/${GITHUB_REPOSITORY}/archive/${GITHUB_SHA}.tar.gz"
+          tar -xf "${LIBRARY}-${GITHUB_SHA}.tar.gz"
+          if [ ! -d "${LIBRARY}-${GITHUB_SHA}" ]
+          then
+              echo "Library snapshot does not contain the library directory ${LIBRARY}-${GITHUB_SHA}:"
+              ls -la
+              exit 1
+          fi
+          rm -f "${LIBRARY}-${GITHUB_SHA}.tar.gz"
           cd ..
-          git clone -b $BOOST_BRANCH --depth 1 https://github.com/boostorg/boost.git boost-root
+          git clone -b "$BOOST_BRANCH" --depth 1 "https://github.com/boostorg/boost.git" "boost-root"
           cd boost-root
-          cp -r $GITHUB_WORKSPACE/* libs/$LIBRARY
+          mkdir -p libs
+          rm -rf "libs/$LIBRARY"
+          mv -f "../snapshot/${LIBRARY}-${GITHUB_SHA}" "libs/$LIBRARY"
+          rm -rf "../snapshot"
           git submodule update --init tools/boostdep
-          python3 tools/boostdep/depinst/depinst.py -I examples $LIBRARY
+          DEPINST_ARGS+=("-I" "examples" "$LIBRARY")
+          python3 tools/boostdep/depinst/depinst.py "${DEPINST_ARGS[@]}"
           ./bootstrap.sh
           ./b2 -d0 headers
 
@@ -276,7 +317,7 @@ jobs:
 
       - name: Run tests
         run: |
-          cd ../boost-root
+          cd boost-root
           ADDRMD=${{matrix.address-model}}
           INSTRUCTION_SET=${{matrix.instruction-set}}
           if [ -n "${{matrix.cpu-requirements}}" ]
@@ -324,8 +365,6 @@ jobs:
     runs-on: ${{matrix.os}}
 
     steps:
-      - uses: actions/checkout@v4
-
       - name: Setup Boost
         shell: cmd
         run: |
@@ -339,19 +378,33 @@ jobs:
           set BOOST_BRANCH=develop
           for /f %%i in ("%GITHUB_BASE_REF%") do if "%%~nxi" == "master" set BOOST_BRANCH=master
           echo BOOST_BRANCH: %BOOST_BRANCH%
+          mkdir snapshot
+          cd snapshot
+          echo Downloading library snapshot: https://github.com/%GITHUB_REPOSITORY%/archive/%GITHUB_SHA%.zip
+          curl -L --retry %NET_RETRY_COUNT% -o "%LIBRARY%-%GITHUB_SHA%.zip" "https://github.com/%GITHUB_REPOSITORY%/archive/%GITHUB_SHA%.zip"
+          tar -xf "%LIBRARY%-%GITHUB_SHA%.zip"
+          if not exist "%LIBRARY%-%GITHUB_SHA%\" (
+              echo Library snapshot does not contain the library directory %LIBRARY%-%GITHUB_SHA%:
+              dir
+              exit /b 1
+          )
+          del /f "%LIBRARY%-%GITHUB_SHA%.zip"
           cd ..
           git clone -b %BOOST_BRANCH% --depth 1 https://github.com/boostorg/boost.git boost-root
           cd boost-root
-          xcopy /s /e /q %GITHUB_WORKSPACE% libs\%LIBRARY%\
+          if not exist "libs\" mkdir libs
+          if exist "libs\%LIBRARY%\" rmdir /s /q "libs\%LIBRARY%"
+          move /Y "..\snapshot\%LIBRARY%-%GITHUB_SHA%" "libs\%LIBRARY%"
+          rmdir /s /q "..\snapshot"
           git submodule update --init tools/boostdep
-          python tools/boostdep/depinst/depinst.py -I examples --git_args "--jobs 3" %LIBRARY%
+          python tools/boostdep/depinst/depinst.py -I examples --git_args "--jobs %GIT_FETCH_JOBS%" %LIBRARY%
           cmd /c bootstrap
           b2 -d0 headers
 
       - name: Run tests
         shell: cmd
         run: |
-          cd ../boost-root
+          cd boost-root
           b2 -j2 libs/%LIBRARY%/test toolset=${{matrix.toolset}} cxxstd=${{matrix.cxxstd}} address-model=${{matrix.addrmd}} variant=debug,release embed-manifest-via=linker
 
   posix-cmake-subdir:
@@ -371,11 +424,11 @@ jobs:
     runs-on: ${{matrix.os}}
 
     steps:
-      - uses: actions/checkout@v4
-
       - name: Install packages
         if: matrix.install
-        run: sudo apt-get -y install ${{matrix.install}}
+        run: |
+          sudo apt-get -o Acquire::Retries=$NET_RETRY_COUNT update
+          sudo apt-get -o Acquire::Retries=$NET_RETRY_COUNT -y install ${{join(matrix.install, ' ')}}
 
       - name: Setup Boost
         run: |
@@ -390,16 +443,31 @@ jobs:
           echo REF: $REF
           BOOST_BRANCH=develop && [ "$REF" == "master" ] && BOOST_BRANCH=master || true
           echo BOOST_BRANCH: $BOOST_BRANCH
+          mkdir -p snapshot
+          cd snapshot
+          echo "Downloading library snapshot: https://github.com/${GITHUB_REPOSITORY}/archive/${GITHUB_SHA}.tar.gz"
+          curl -L --retry "$NET_RETRY_COUNT" -o "${LIBRARY}-${GITHUB_SHA}.tar.gz" "https://github.com/${GITHUB_REPOSITORY}/archive/${GITHUB_SHA}.tar.gz"
+          tar -xf "${LIBRARY}-${GITHUB_SHA}.tar.gz"
+          if [ ! -d "${LIBRARY}-${GITHUB_SHA}" ]
+          then
+              echo "Library snapshot does not contain the library directory ${LIBRARY}-${GITHUB_SHA}:"
+              ls -la
+              exit 1
+          fi
+          rm -f "${LIBRARY}-${GITHUB_SHA}.tar.gz"
           cd ..
-          git clone -b $BOOST_BRANCH --depth 1 https://github.com/boostorg/boost.git boost-root
+          git clone -b "$BOOST_BRANCH" --depth 1 "https://github.com/boostorg/boost.git" "boost-root"
           cd boost-root
-          cp -r $GITHUB_WORKSPACE/* libs/$LIBRARY
+          mkdir -p libs
+          rm -rf "libs/$LIBRARY"
+          mv -f "../snapshot/${LIBRARY}-${GITHUB_SHA}" "libs/$LIBRARY"
+          rm -rf "../snapshot"
           git submodule update --init tools/boostdep
-          python tools/boostdep/depinst/depinst.py --git_args "--jobs 3" $LIBRARY
+          python tools/boostdep/depinst/depinst.py --git_args "--jobs $GIT_FETCH_JOBS" $LIBRARY
 
       - name: Use library with add_subdirectory
         run: |
-          cd ../boost-root/libs/$LIBRARY/test/cmake_subdir_test
+          cd "boost-root/libs/$LIBRARY/test/cmake_subdir_test"
           mkdir __build__ && cd __build__
           cmake ${{matrix.opts}} ..
           cmake --build .
@@ -422,11 +490,11 @@ jobs:
     runs-on: ${{matrix.os}}
 
     steps:
-      - uses: actions/checkout@v4
-
       - name: Install packages
         if: matrix.install
-        run: sudo apt-get -y install ${{matrix.install}}
+        run: |
+          sudo apt-get -o Acquire::Retries=$NET_RETRY_COUNT update
+          sudo apt-get -o Acquire::Retries=$NET_RETRY_COUNT -y install ${{join(matrix.install, ' ')}}
 
       - name: Setup Boost
         run: |
@@ -441,27 +509,42 @@ jobs:
           echo REF: $REF
           BOOST_BRANCH=develop && [ "$REF" == "master" ] && BOOST_BRANCH=master || true
           echo BOOST_BRANCH: $BOOST_BRANCH
+          mkdir -p snapshot
+          cd snapshot
+          echo "Downloading library snapshot: https://github.com/${GITHUB_REPOSITORY}/archive/${GITHUB_SHA}.tar.gz"
+          curl -L --retry "$NET_RETRY_COUNT" -o "${LIBRARY}-${GITHUB_SHA}.tar.gz" "https://github.com/${GITHUB_REPOSITORY}/archive/${GITHUB_SHA}.tar.gz"
+          tar -xf "${LIBRARY}-${GITHUB_SHA}.tar.gz"
+          if [ ! -d "${LIBRARY}-${GITHUB_SHA}" ]
+          then
+              echo "Library snapshot does not contain the library directory ${LIBRARY}-${GITHUB_SHA}:"
+              ls -la
+              exit 1
+          fi
+          rm -f "${LIBRARY}-${GITHUB_SHA}.tar.gz"
           cd ..
-          git clone -b $BOOST_BRANCH --depth 1 https://github.com/boostorg/boost.git boost-root
+          git clone -b "$BOOST_BRANCH" --depth 1 "https://github.com/boostorg/boost.git" "boost-root"
           cd boost-root
-          cp -r $GITHUB_WORKSPACE/* libs/$LIBRARY
+          mkdir -p libs
+          rm -rf "libs/$LIBRARY"
+          mv -f "../snapshot/${LIBRARY}-${GITHUB_SHA}" "libs/$LIBRARY"
+          rm -rf "../snapshot"
           git submodule update --init tools/boostdep
-          python tools/boostdep/depinst/depinst.py --git_args "--jobs 3" $LIBRARY
+          python tools/boostdep/depinst/depinst.py --git_args "--jobs $GIT_FETCH_JOBS" $LIBRARY
 
       - name: Configure
         run: |
-          cd ../boost-root
+          cd boost-root
           mkdir __build__ && cd __build__
           cmake -DBOOST_INCLUDE_LIBRARIES=$LIBRARY -DCMAKE_INSTALL_PREFIX=~/.local ${{matrix.opts}} ..
 
       - name: Install
         run: |
-          cd ../boost-root/__build__
+          cd boost-root/__build__
           cmake --build . --target install
 
       - name: Use the installed library
         run: |
-          cd ../boost-root/libs/$LIBRARY/test/cmake_install_test && mkdir __build__ && cd __build__
+          cd "boost-root/libs/$LIBRARY/test/cmake_install_test" && mkdir __build__ && cd __build__
           cmake -DCMAKE_INSTALL_PREFIX=~/.local ${{matrix.opts}} ..
           cmake --build .
           ctest --output-on-failure --no-tests=error
@@ -483,11 +566,11 @@ jobs:
     runs-on: ${{matrix.os}}
 
     steps:
-      - uses: actions/checkout@v4
-
       - name: Install packages
         if: matrix.install
-        run: sudo apt-get -y install ${{matrix.install}}
+        run: |
+          sudo apt-get -o Acquire::Retries=$NET_RETRY_COUNT update
+          sudo apt-get -o Acquire::Retries=$NET_RETRY_COUNT -y install ${{join(matrix.install, ' ')}}
 
       - name: Setup Boost
         run: |
@@ -502,27 +585,42 @@ jobs:
           echo REF: $REF
           BOOST_BRANCH=develop && [ "$REF" == "master" ] && BOOST_BRANCH=master || true
           echo BOOST_BRANCH: $BOOST_BRANCH
+          mkdir -p snapshot
+          cd snapshot
+          echo "Downloading library snapshot: https://github.com/${GITHUB_REPOSITORY}/archive/${GITHUB_SHA}.tar.gz"
+          curl -L --retry "$NET_RETRY_COUNT" -o "${LIBRARY}-${GITHUB_SHA}.tar.gz" "https://github.com/${GITHUB_REPOSITORY}/archive/${GITHUB_SHA}.tar.gz"
+          tar -xf "${LIBRARY}-${GITHUB_SHA}.tar.gz"
+          if [ ! -d "${LIBRARY}-${GITHUB_SHA}" ]
+          then
+              echo "Library snapshot does not contain the library directory ${LIBRARY}-${GITHUB_SHA}:"
+              ls -la
+              exit 1
+          fi
+          rm -f "${LIBRARY}-${GITHUB_SHA}.tar.gz"
           cd ..
-          git clone -b $BOOST_BRANCH --depth 1 https://github.com/boostorg/boost.git boost-root
+          git clone -b "$BOOST_BRANCH" --depth 1 "https://github.com/boostorg/boost.git" "boost-root"
           cd boost-root
-          cp -r $GITHUB_WORKSPACE/* libs/$LIBRARY
+          mkdir -p libs
+          rm -rf "libs/$LIBRARY"
+          mv -f "../snapshot/${LIBRARY}-${GITHUB_SHA}" "libs/$LIBRARY"
+          rm -rf "../snapshot"
           git submodule update --init tools/boostdep
-          python tools/boostdep/depinst/depinst.py --git_args "--jobs 3" $LIBRARY
+          python tools/boostdep/depinst/depinst.py --git_args "--jobs $GIT_FETCH_JOBS" $LIBRARY
 
       - name: Configure
         run: |
-          cd ../boost-root
+          cd boost-root
           mkdir __build__ && cd __build__
           cmake -DBOOST_INCLUDE_LIBRARIES=$LIBRARY -DBUILD_TESTING=ON ${{matrix.opts}} ..
 
       - name: Build tests
         run: |
-          cd ../boost-root/__build__
+          cd boost-root/__build__
           cmake --build . --target tests
 
       - name: Run tests
         run: |
-          cd ../boost-root/__build__
+          cd boost-root/__build__
           ctest --output-on-failure --no-tests=error
 
   windows-cmake-subdir:
@@ -540,8 +638,6 @@ jobs:
     runs-on: ${{matrix.os}}
 
     steps:
-      - uses: actions/checkout@v4
-
       - name: Setup Boost
         shell: cmd
         run: |
@@ -555,17 +651,31 @@ jobs:
           set BOOST_BRANCH=develop
           for /f %%i in ("%GITHUB_BASE_REF%") do if "%%~nxi" == "master" set BOOST_BRANCH=master
           echo BOOST_BRANCH: %BOOST_BRANCH%
+          mkdir snapshot
+          cd snapshot
+          echo Downloading library snapshot: https://github.com/%GITHUB_REPOSITORY%/archive/%GITHUB_SHA%.zip
+          curl -L --retry %NET_RETRY_COUNT% -o "%LIBRARY%-%GITHUB_SHA%.zip" "https://github.com/%GITHUB_REPOSITORY%/archive/%GITHUB_SHA%.zip"
+          tar -xf "%LIBRARY%-%GITHUB_SHA%.zip"
+          if not exist "%LIBRARY%-%GITHUB_SHA%\" (
+              echo Library snapshot does not contain the library directory %LIBRARY%-%GITHUB_SHA%:
+              dir
+              exit /b 1
+          )
+          del /f "%LIBRARY%-%GITHUB_SHA%.zip"
           cd ..
           git clone -b %BOOST_BRANCH% --depth 1 https://github.com/boostorg/boost.git boost-root
           cd boost-root
-          xcopy /s /e /q %GITHUB_WORKSPACE% libs\%LIBRARY%\
+          if not exist "libs\" mkdir libs
+          if exist "libs\%LIBRARY%\" rmdir /s /q "libs\%LIBRARY%"
+          move /Y "..\snapshot\%LIBRARY%-%GITHUB_SHA%" "libs\%LIBRARY%"
+          rmdir /s /q "..\snapshot"
           git submodule update --init tools/boostdep
-          python tools/boostdep/depinst/depinst.py --git_args "--jobs 3" %LIBRARY%
+          python tools/boostdep/depinst/depinst.py --git_args "--jobs %GIT_FETCH_JOBS%" %LIBRARY%
 
       - name: Use library with add_subdirectory (Debug)
         shell: cmd
         run: |
-          cd ../boost-root/libs/%LIBRARY%/test/cmake_subdir_test
+          cd "boost-root/libs/%LIBRARY%/test/cmake_subdir_test"
           mkdir __build__ && cd __build__
           cmake ${{matrix.opts}} ..
           cmake --build . --config Debug
@@ -574,7 +684,7 @@ jobs:
       - name: Use library with add_subdirectory (Release)
         shell: cmd
         run: |
-          cd ../boost-root/libs/%LIBRARY%/test/cmake_subdir_test/__build__
+          cd "boost-root/libs/%LIBRARY%/test/cmake_subdir_test/__build__"
           cmake --build . --config Release
           ctest --output-on-failure --no-tests=error -C Release
 
@@ -593,8 +703,6 @@ jobs:
     runs-on: ${{matrix.os}}
 
     steps:
-      - uses: actions/checkout@v4
-
       - name: Setup Boost
         shell: cmd
         run: |
@@ -608,36 +716,50 @@ jobs:
           set BOOST_BRANCH=develop
           for /f %%i in ("%GITHUB_BASE_REF%") do if "%%~nxi" == "master" set BOOST_BRANCH=master
           echo BOOST_BRANCH: %BOOST_BRANCH%
+          mkdir snapshot
+          cd snapshot
+          echo Downloading library snapshot: https://github.com/%GITHUB_REPOSITORY%/archive/%GITHUB_SHA%.zip
+          curl -L --retry %NET_RETRY_COUNT% -o "%LIBRARY%-%GITHUB_SHA%.zip" "https://github.com/%GITHUB_REPOSITORY%/archive/%GITHUB_SHA%.zip"
+          tar -xf "%LIBRARY%-%GITHUB_SHA%.zip"
+          if not exist "%LIBRARY%-%GITHUB_SHA%\" (
+              echo Library snapshot does not contain the library directory %LIBRARY%-%GITHUB_SHA%:
+              dir
+              exit /b 1
+          )
+          del /f "%LIBRARY%-%GITHUB_SHA%.zip"
           cd ..
           git clone -b %BOOST_BRANCH% --depth 1 https://github.com/boostorg/boost.git boost-root
           cd boost-root
-          xcopy /s /e /q %GITHUB_WORKSPACE% libs\%LIBRARY%\
+          if not exist "libs\" mkdir libs
+          if exist "libs\%LIBRARY%\" rmdir /s /q "libs\%LIBRARY%"
+          move /Y "..\snapshot\%LIBRARY%-%GITHUB_SHA%" "libs\%LIBRARY%"
+          rmdir /s /q "..\snapshot"
           git submodule update --init tools/boostdep
-          python tools/boostdep/depinst/depinst.py --git_args "--jobs 3" %LIBRARY%
+          python tools/boostdep/depinst/depinst.py --git_args "--jobs %GIT_FETCH_JOBS%" %LIBRARY%
 
       - name: Configure
         shell: cmd
         run: |
-          cd ../boost-root
+          cd boost-root
           mkdir __build__ && cd __build__
           cmake -DBOOST_INCLUDE_LIBRARIES=%LIBRARY% -DCMAKE_INSTALL_PREFIX=C:/cmake-prefix ${{matrix.opts}} ..
 
       - name: Install (Debug)
         shell: cmd
         run: |
-          cd ../boost-root/__build__
+          cd boost-root/__build__
           cmake --build . --target install --config Debug
 
       - name: Install (Release)
         shell: cmd
         run: |
-          cd ../boost-root/__build__
+          cd boost-root/__build__
           cmake --build . --target install --config Release
 
       - name: Use the installed library (Debug)
         shell: cmd
         run: |
-          cd ../boost-root/libs/%LIBRARY%/test/cmake_install_test && mkdir __build__ && cd __build__
+          cd "boost-root/libs/%LIBRARY%/test/cmake_install_test" && mkdir __build__ && cd __build__
           cmake -DCMAKE_INSTALL_PREFIX=C:/cmake-prefix ${{matrix.opts}} ..
           cmake --build . --config Debug
           ctest --output-on-failure --no-tests=error -C Debug
@@ -645,7 +767,7 @@ jobs:
       - name: Use the installed library (Release)
         shell: cmd
         run: |
-          cd ../boost-root/libs/%LIBRARY%/test/cmake_install_test/__build__
+          cd "boost-root/libs/%LIBRARY%/test/cmake_install_test/__build__"
           cmake --build . --config Release
           ctest --output-on-failure --no-tests=error -C Release
 
@@ -664,8 +786,6 @@ jobs:
     runs-on: ${{matrix.os}}
 
     steps:
-      - uses: actions/checkout@v4
-
       - name: Setup Boost
         shell: cmd
         run: |
@@ -679,40 +799,54 @@ jobs:
           set BOOST_BRANCH=develop
           for /f %%i in ("%GITHUB_BASE_REF%") do if "%%~nxi" == "master" set BOOST_BRANCH=master
           echo BOOST_BRANCH: %BOOST_BRANCH%
+          mkdir snapshot
+          cd snapshot
+          echo Downloading library snapshot: https://github.com/%GITHUB_REPOSITORY%/archive/%GITHUB_SHA%.zip
+          curl -L --retry %NET_RETRY_COUNT% -o "%LIBRARY%-%GITHUB_SHA%.zip" "https://github.com/%GITHUB_REPOSITORY%/archive/%GITHUB_SHA%.zip"
+          tar -xf "%LIBRARY%-%GITHUB_SHA%.zip"
+          if not exist "%LIBRARY%-%GITHUB_SHA%\" (
+              echo Library snapshot does not contain the library directory %LIBRARY%-%GITHUB_SHA%:
+              dir
+              exit /b 1
+          )
+          del /f "%LIBRARY%-%GITHUB_SHA%.zip"
           cd ..
           git clone -b %BOOST_BRANCH% --depth 1 https://github.com/boostorg/boost.git boost-root
           cd boost-root
-          xcopy /s /e /q %GITHUB_WORKSPACE% libs\%LIBRARY%\
+          if not exist "libs\" mkdir libs
+          if exist "libs\%LIBRARY%\" rmdir /s /q "libs\%LIBRARY%"
+          move /Y "..\snapshot\%LIBRARY%-%GITHUB_SHA%" "libs\%LIBRARY%"
+          rmdir /s /q "..\snapshot"
           git submodule update --init tools/boostdep
-          python tools/boostdep/depinst/depinst.py --git_args "--jobs 3" %LIBRARY%
+          python tools/boostdep/depinst/depinst.py --git_args "--jobs %GIT_FETCH_JOBS%" %LIBRARY%
 
       - name: Configure
         shell: cmd
         run: |
-          cd ../boost-root
+          cd boost-root
           mkdir __build__ && cd __build__
           cmake -DBOOST_INCLUDE_LIBRARIES=%LIBRARY% -DBUILD_TESTING=ON ${{matrix.opts}} ..
 
       - name: Build tests (Debug)
         shell: cmd
         run: |
-          cd ../boost-root/__build__
+          cd boost-root/__build__
           cmake --build . --target tests --config Debug
 
       - name: Run tests (Debug)
         shell: cmd
         run: |
-          cd ../boost-root/__build__
+          cd boost-root/__build__
           ctest --output-on-failure --no-tests=error -C Debug
 
       - name: Build tests (Release)
         shell: cmd
         run: |
-          cd ../boost-root/__build__
+          cd boost-root/__build__
           cmake --build . --target tests --config Release
 
       - name: Run tests (Release)
         shell: cmd
         run: |
-          cd ../boost-root/__build__
+          cd boost-root/__build__
           ctest --output-on-failure --no-tests=error -C Release


### PR DESCRIPTION
GitHub actions/checkout@v3 is no longer working and v4 is incompatible with older Linux versions due to https://github.com/actions/checkout/issues/1590. To fix this, and permanently eliminate the issue of periodic deprecation of actions/checkout, replace it with manual downloads of git snapshots using curl.

Additionally, fixed apt command lines that would incorrectly expand the list of packages to install. Added options to retry on network errors to reduce the probability of spurious CI failures. Also added git checkout parallel jobs to potentially speed up the checkout.

This should fix CI failures with actions/checkout@v3 and eliminate GHA deprecation warnings.