### PR TITLE
Fix missing-field-initializers error in GCC 4.8 and 4.9

### DIFF
--- a/include/boost/uuid/uuid.hpp
+++ b/include/boost/uuid/uuid.hpp
@@ -266,7 +266,7 @@ public:
 
     node_type node_identifier() const noexcept
     {
-        node_type node = {};
+        node_type node = {{}};
 
         std::memcpy( node.data(), this->data + 10, 6 );
         return node;


### PR DESCRIPTION
Failure seen in [unordered#274](https://github.com/boostorg/unordered/pull/274)
[CE link](https://godbolt.org/z/dcYes3PTc)