### PR TITLE
Optimize generic `is_nil`

### DIFF
--- a/include/boost/uuid/detail/uuid_generic.ipp
+++ b/include/boost/uuid/detail/uuid_generic.ipp
@@ -23,7 +23,7 @@ inline bool uuid::is_nil() const noexcept
     std::uint64_t v = detail::load_native_u64( this->data + 0 );
     std::uint64_t w = detail::load_native_u64( this->data + 8 );
 
-    return v == 0 && w == 0;
+    return ( v | w ) == 0u;
 }
 
 inline void uuid::swap( uuid& rhs ) noexcept


### PR DESCRIPTION
Reduce the number of generated branches in the generic `is_nil` by using bitwise operations.

Note that a similar optimization is possible for `operator==`, but in that case there may be a slight reduction in performance if UUIDs are mostly unequal, and a slight speedup if they are mostly equal. If you're interested, I can add the change to `operator==` as well.
