### PR TITLE
Add RFC-9562 compliant Max UUID (section 5.10)

### DIFF
--- a/include/boost/uuid/max_generator.hpp
+++ b/include/boost/uuid/max_generator.hpp
@@ -1,0 +1,39 @@
+#ifndef BOOST_UUID_MAX_GENERATOR_HPP_INCLUDED
+#define BOOST_UUID_MAX_GENERATOR_HPP_INCLUDED
+
+// Copyright 2025 James E. King III
+// Distributed under the Boost Software License, Version 1.0.
+// https://www.boost.org/LICENSE_1_0.txt
+
+// RFC 9562 section 5.10
+
+#include <boost/uuid/uuid.hpp>
+
+namespace boost {
+namespace uuids {
+
+// generate a max uuid
+struct max_generator
+{
+    using result_type = uuid;
+    
+    uuid operator()() const noexcept
+    {
+        return {{ 
+            0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF,
+            0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF
+        }};
+    }
+};
+
+inline uuid max_uuid() noexcept
+{
+    return {{ 
+        0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF,
+        0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF
+    }};
+}
+
+}} // namespace boost::uuids
+
+#endif // BOOST_UUID_MAX_GENERATOR_HPP_INCLUDED

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -36,6 +36,7 @@ boost_test(TYPE run SOURCES test_to_chars_2.cpp)
 
 boost_test(TYPE run SOURCES test_uuid_clock.cpp)
 
+boost_test(TYPE run SOURCES test_max_generator.cpp)
 boost_test(TYPE run SOURCES test_nil_generator.cpp)
 boost_test(TYPE run SOURCES test_string_generator.cpp)
 boost_test(TYPE run SOURCES test_random_generator.cpp LINK_LIBRARIES Boost::random Boost::predef)

--- a/test/Jamfile.v2
+++ b/test/Jamfile.v2
@@ -100,6 +100,7 @@ run test_uuid_clock.cpp ;
 
 # test generators
 
+run test_max_generator.cpp ;
 run test_nil_generator.cpp ;
 run test_string_generator.cpp ;
 

--- a/test/test_max_generator.cpp
+++ b/test/test_max_generator.cpp
@@ -1,0 +1,31 @@
+// Copyright (C) 2025 James E. King III
+// Distributed under the Boost Software License, Version 1.0. (See
+// accompanying file LICENSE_1_0.txt or copy at
+// https://www.boost.org/LICENSE_1_0.txt)
+
+//  libs/uuid/test/test_max_generator.cpp  -------------------------------//
+
+#include <boost/uuid/uuid.hpp>
+#include <boost/uuid/uuid_io.hpp>
+#include <boost/uuid/max_generator.hpp>
+#include <boost/uuid/nil_generator.hpp>
+#include <boost/detail/lightweight_test.hpp>
+
+int main(int, char*[])
+{
+    using namespace boost::uuids;
+
+    uuid uunil = nil_generator()();
+    uuid uumax = max_generator()();
+    uuid expected = {{ 
+        0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF,
+        0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF
+    }};
+    BOOST_TEST_EQ(uumax, expected);
+    BOOST_TEST_LT(uunil, uumax);
+
+    uuid u3 = max_uuid();
+    BOOST_TEST_EQ(u3, expected);
+
+    return boost::report_errors();
+}


### PR DESCRIPTION
Section 5.10 of https://datatracker.ietf.org/doc/rfc9562/ defines a "max" uuid which is not present in boost::uuid.

The clang-win build issue is a known issue: https://github.com/actions/runner-images/issues/12435