### PR TITLE
Remove dependencies on Boost.StaticAssert

### DIFF
--- a/test/cmake_subdir_test/CMakeLists.txt
+++ b/test/cmake_subdir_test/CMakeLists.txt
@@ -21,7 +21,6 @@ type_traits
 
 # Secondary dependencies
 
-static_assert
 )
 
 foreach(dep IN LISTS deps)


### PR DESCRIPTION
Boost.StaticAssert has been merged into Boost.Config, so remove the dependency.