### PR TITLE
Add time_generator_v7::operator() overload for caller provided time point

### DIFF
--- a/doc/uuid/time_generator_v7.adoc
+++ b/doc/uuid/time_generator_v7.adoc
@@ -31,6 +31,7 @@ public:
     time_generator_v7& operator=( time_generator_v7&& rhs ) noexcept;
 
     result_type operator()() noexcept;
+    result_type operator()( std::chrono::time_point<std::chrono::system_clock> const& time_point ) noexcept;
 };
 
 }} // namespace boost::uuids
@@ -100,3 +101,10 @@ Remarks: :: `operator()` generates a monotonically increasing sequence of UUIDs,
 * The system clock never goes backwards.
 * The system clock has at least millisecond resolution.
 * No more than 64 UUIDs are generated per microsecond (no more than one every 16 nanoseconds).
+
+```
+result_type operator()( std::chrono::time_point<std::chrono::system_clock> const& time_point ) noexcept;
+```
+
+Effects: :: The same as `operator()()` but allows the caller to provide the system time
+Remarks: :: The same as `operator()()`

--- a/include/boost/uuid/time_generator_v7.hpp
+++ b/include/boost/uuid/time_generator_v7.hpp
@@ -46,10 +46,11 @@ public:
     time_generator_v7& operator=( time_generator_v7&& rhs ) noexcept;
 
     result_type operator()() noexcept;
+    result_type operator()( std::chrono::time_point<std::chrono::system_clock> const& time_point ) noexcept;
 
 private:
 
-    static state_type get_new_state( state_type const& oldst ) noexcept;
+    static state_type get_new_state( state_type const& oldst, std::chrono::time_point<std::chrono::system_clock> const& time_point = std::chrono::system_clock::now() ) noexcept;
 };
 
 // constructors
@@ -91,10 +92,10 @@ inline time_generator_v7& time_generator_v7::operator=( time_generator_v7&& rhs 
 
 // get_new_state
 
-inline time_generator_v7::state_type time_generator_v7::get_new_state( state_type const& oldst ) noexcept
+inline time_generator_v7::state_type time_generator_v7::get_new_state( state_type const& oldst, std::chrono::time_point<std::chrono::system_clock> const& time_point ) noexcept
 {
     // `now()` in microseconds
-    std::uint64_t now_in_us = static_cast<std::uint64_t>( std::chrono::time_point_cast< std::chrono::microseconds >( std::chrono::system_clock::now() ).time_since_epoch().count() );
+    std::uint64_t now_in_us = static_cast<std::uint64_t>( std::chrono::time_point_cast< std::chrono::microseconds >( time_point ).time_since_epoch().count() );
 
     std::uint64_t time_ms = now_in_us / 1000; // timestamp, ms part
     std::uint64_t time_us = now_in_us % 1000; // timestamp, us part
@@ -119,7 +120,7 @@ inline time_generator_v7::state_type time_generator_v7::get_new_state( state_typ
 
 // operator()
 
-inline time_generator_v7::result_type time_generator_v7::operator()() noexcept
+inline time_generator_v7::result_type time_generator_v7::operator()( std::chrono::time_point<std::chrono::system_clock> const& time_point ) noexcept
 {
     uuid result;
 
@@ -131,7 +132,7 @@ inline time_generator_v7::result_type time_generator_v7::operator()() noexcept
     detail::store_native_u32( result.data + 12, dist( rng_ ) );
 
     // get new timestamp
-    state_ = get_new_state( state_ );
+    state_ = get_new_state( state_, time_point );
 
     std::uint64_t time_ms = state_ >> 16; // timestamp, ms part
     std::uint64_t time_us = ( state_ & 0xFFFF ) >> 6; // timestamp, us part
@@ -145,6 +146,11 @@ inline time_generator_v7::result_type time_generator_v7::operator()() noexcept
     result.data[ 8 ] = static_cast< std::uint8_t >( 0x80 | ( state_ & 0x3F ) );
 
     return result;
+}
+
+inline time_generator_v7::result_type time_generator_v7::operator()() noexcept
+{
+    return operator()(std::chrono::system_clock::now());
 }
 
 }} // namespace boost::uuids


### PR DESCRIPTION
This can be useful to tag existing time stamped data.

Implements #193 